### PR TITLE
밈 기본 API 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,4 +41,18 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
   },
+  overrides: [
+    {
+      files: ['**/*.ts'],
+      parserOptions: {
+        project: ['./tsconfig.json'],
+      },
+    },
+    {
+      files: ['jest.config.js'],
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+  ],
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 .env
+
+coverage/*

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFilesAfterEnv: ['./test/setup.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ppac-server",
+  "name": "farmeme",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ppac-server",
+      "name": "farmeme",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -25,6 +25,7 @@
         "@types/node": "^20.12.2",
         "@types/pino": "^7.0.5",
         "@types/pino-pretty": "^5.0.0",
+        "@types/supertest": "^6.0.2",
         "@types/yamljs": "^0.2.34",
         "@typescript-eslint/eslint-plugin": "^7.7.0",
         "eslint": "^8.9.0",
@@ -32,9 +33,12 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "^5.1.3",
         "jest": "^29.7.0",
+        "mongodb-memory-server": "^9.3.0",
         "mongoose": "^8.0.3",
         "nodemon": "^3.0.2",
         "prettier": "^3.2.5",
+        "supertest": "^7.0.0",
+        "ts-jest": "^29.1.4",
         "typescript": "^5.3.0"
       }
     },
@@ -888,6 +892,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1381,6 +1391,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true
+    },
     "node_modules/@types/dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
@@ -1476,6 +1492,12 @@
       "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
       "dev": true
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1549,6 +1571,27 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.7",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.7.tgz",
+      "integrity": "sha512-NmIsd0Yj4DDhftfWvvAku482PZum4DBW7U51OvS8gvOkDDY0WT1jsVyDV3hK+vplrsYw8oDwi9QxOM7U68iwww==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
+      "integrity": "sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -1556,11 +1599,12 @@
       "dev": true
     },
     "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "dev": true,
       "dependencies": {
+        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -1801,9 +1845,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1821,11 +1865,26 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2047,6 +2106,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2069,6 +2149,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2191,6 +2277,13 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/bare-events": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2311,6 +2404,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -2321,12 +2426,12 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.7.0.tgz",
-      "integrity": "sha512-w2IquM5mYzYZv6rs3uN2DZTOBe2a0zXLj53TGDqwF4l6Sz/XsISrisXOJihArF9+BZ6Cq/GjVht7Sjfmri7ytQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "dev": true,
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/buffer": {
@@ -2350,6 +2455,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -2403,9 +2517,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001633",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001633.tgz",
-      "integrity": "sha512-6sT0yf/z5jqf8tISAgpJDrmwOpLsrpnyCdD/lOZKvKkkJK4Dn0X5i7KF7THEZhOq+30bmhwBlNEaqPUiHiKtZg==",
+      "version": "1.0.30001634",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001634.tgz",
+      "integrity": "sha512-fbBYXQ9q3+yp1q1gBk86tOFs4pyn/yxFm5ZNP18OXJDfA3txImOY9PhfxVggZ4vRHDqoU8NrKU81eN0OtzOgRA==",
       "dev": true,
       "funding": [
         {
@@ -2557,6 +2671,33 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2599,6 +2740,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2778,6 +2925,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2802,6 +2958,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -2862,9 +3028,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.802",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.802.tgz",
-      "integrity": "sha512-TnTMUATbgNdPXVSHsxvNVSG0uEd6cSZsANjm8c9HbvflZVVn1yTRcmVXYT1Ma95/ssB/Dcd30AHweH2TE+dNpA==",
+      "version": "1.4.803",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.803.tgz",
+      "integrity": "sha512-61H9mLzGOCLLVsnLiRzCbc63uldP0AniRYPV3hbGVtONA1pI7qSGILdbofR7A8TMbOypDocEAjH/e+9k1QIe3g==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3558,6 +3724,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -3683,6 +3855,47 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3719,6 +3932,26 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3726,6 +3959,34 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4080,6 +4341,15 @@
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
     },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4099,6 +4369,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -4226,6 +4509,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -5195,6 +5491,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5317,6 +5619,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5480,6 +5788,146 @@
       }
     },
     "node_modules/mongodb": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "dev": true,
+      "dependencies": {
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-memory-server": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.3.0.tgz",
+      "integrity": "sha512-ag1vbjsm1A2C/1arRlfCLRapY7L2JKsQgASvaFyTXFyfqf6wjVSfO3PhJ/KfkyntmwlMXe3sUjMkZKeD89qu8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "mongodb-memory-server-core": "9.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.3.0.tgz",
+      "integrity": "sha512-8okAtOGWqSG37K7/TrvTfn43ORMh9LssIvd30XjHxvjWK7utmSTXr69XAhYvsDrHDwv7L23Ii6NJ4zMPpiFKuw==",
+      "dev": true,
+      "dependencies": {
+        "async-mutex": "^0.4.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.4",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^7.0.4",
+        "mongodb": "^5.9.1",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.6.2",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.6.2",
+        "yauzl": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.4.1.tgz",
+      "integrity": "sha512-odQ2WEWGL3hb0Qex+QMN4eH6D34WdMEw7F1If2MGABApSDmG9cMmqv/G1H6WsXmuaH9mkuuadW/WbLE5+tHJwA==",
+      "dev": true,
+      "dependencies": {
+        "bson": "^6.7.0",
+        "kareem": "2.6.3",
+        "mongodb": "6.6.2",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongoose/node_modules/bson": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.7.0.tgz",
+      "integrity": "sha512-w2IquM5mYzYZv6rs3uN2DZTOBe2a0zXLj53TGDqwF4l6Sz/XsISrisXOJihArF9+BZ6Cq/GjVht7Sjfmri7ytQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.6.2.tgz",
       "integrity": "sha512-ZF9Ugo2JCG/GfR7DEb4ypfyJJyiKbg5qBYKRintebj8+DNS33CyGMkWbrS9lara+u+h+yEOGSRiLhFO/g1s1aw==",
@@ -5525,7 +5973,7 @@
         }
       }
     },
-    "node_modules/mongodb-connection-string-url": {
+    "node_modules/mongoose/node_modules/mongodb-connection-string-url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
       "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
@@ -5535,33 +5983,36 @@
         "whatwg-url": "^13.0.0"
       }
     },
-    "node_modules/mongoose": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.4.1.tgz",
-      "integrity": "sha512-odQ2WEWGL3hb0Qex+QMN4eH6D34WdMEw7F1If2MGABApSDmG9cMmqv/G1H6WsXmuaH9mkuuadW/WbLE5+tHJwA==",
-      "dev": true,
-      "dependencies": {
-        "bson": "^6.7.0",
-        "kareem": "2.6.3",
-        "mongodb": "6.6.2",
-        "mpath": "0.9.0",
-        "mquery": "5.0.0",
-        "ms": "2.1.3",
-        "sift": "17.1.3"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mongoose"
-      }
-    },
     "node_modules/mongoose/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/mongoose/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/mongoose/node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/mpath": {
       "version": "0.9.0",
@@ -5602,6 +6053,18 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/node-int64": {
@@ -5974,6 +6437,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -6306,6 +6775,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -6759,6 +7234,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "dev": true,
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.0.1.tgz",
@@ -6804,9 +7303,10 @@
       }
     },
     "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -6835,6 +7335,20 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -6962,6 +7476,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7002,6 +7561,17 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -7038,6 +7608,15 @@
         "node": "*"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.0.tgz",
+      "integrity": "sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7045,9 +7624,9 @@
       "dev": true
     },
     "node_modules/thread-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.0.2.tgz",
-      "integrity": "sha512-cBL4xF2A3lSINV4rD5tyqnKH4z/TgWPvT+NaVhJDSwK962oo/Ye7cHSMbDzwcu7tAE1SfU6Q4XtV6Hucmi6Hlw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -7097,15 +7676,15 @@
       }
     },
     "node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "dev": true,
       "dependencies": {
-        "punycode": "^2.3.0"
+        "punycode": "^2.1.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7118,6 +7697,53 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.1.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.4.tgz",
+      "integrity": "sha512-YiHwDhSvCiItoAgsKtoLFCuakDzDsJ1DLDnSouTaTmdOcOwIkSzbLXduaQ6M5DRVhuZC/NYaaZ/mtHbWMv/S6Q==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "^7.5.3",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-node": {
@@ -7458,16 +8084,16 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "dev": true,
       "dependencies": {
-        "tr46": "^4.1.1",
+        "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -7600,6 +8226,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/yamljs/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -7623,6 +8254,19 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.3.tgz",
+      "integrity": "sha512-JCCdmlJJWv7L0q/KylOekyRaUrdEoUxWkWVcgorosTROCFWiS9p2NNPE9Yb91ak7b1N5SxAZEliWpspbZccivw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "nodemon --exec ts-node --project tsconfig.json src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start:prod": "node dist/index.js",
-    "test": "jest --coverage",
+    "test": "NODE_ENV=test jest",
     "test:watch": "jest --watch",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint ./src/**/*.ts --fix"
@@ -30,6 +30,7 @@
     "@types/node": "^20.12.2",
     "@types/pino": "^7.0.5",
     "@types/pino-pretty": "^5.0.0",
+    "@types/supertest": "^6.0.2",
     "@types/yamljs": "^0.2.34",
     "@typescript-eslint/eslint-plugin": "^7.7.0",
     "eslint": "^8.9.0",
@@ -37,9 +38,12 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
+    "mongodb-memory-server": "^9.3.0",
     "mongoose": "^8.0.3",
     "nodemon": "^3.0.2",
     "prettier": "^3.2.5",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.1.4",
     "typescript": "^5.3.0"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,32 @@
+import express, { Application } from 'express';
+import mongoose from 'mongoose';
+
+import router from './routes';
+import config from './util/config';
+import { attachRequestId, logger } from './util/logger';
+
+const DATABASE_URL = `${config.DB_URL}`;
+
+const app: Application = express();
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+app.get('/', (_, res) => {
+  res.send('Hello! We are Farmeme');
+});
+
+app.use(attachRequestId);
+app.use('/', router);
+
+export const connectToDatabase = async () => {
+  try {
+    await mongoose.connect(DATABASE_URL);
+    logger.info('Connected to MongoDB');
+  } catch (err) {
+    logger.error('Error connecting to MongoDB', err);
+    throw err;
+  }
+};
+
+export default app;

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -10,11 +10,27 @@ import * as MemeService from '../service/meme.service';
 import { logger } from '../util/logger';
 
 const getMeme = async (req: Request, res: Response, next: NextFunction) => {
+  const memeId = req.params?.memeId || null;
+
+  if (_.isNull(memeId)) {
+    return next(new CustomError(`'memeId' field should be provided`, HttpCode.BAD_REQUEST));
+  }
 
   if (!mongoose.Types.ObjectId.isValid(memeId)) {
     return next(new CustomError(`'memeId' is not a valid ObjectId`, HttpCode.BAD_REQUEST));
   }
 
+  try {
+    const meme = await MemeService.getMeme(memeId);
+    if (_.isNull(meme)) {
+      return next(new CustomError(`Meme(${memeId}) not found.`, HttpCode.NOT_FOUND));
+    }
+
+    logger.info(`Get meme - ${memeId})`);
+    return res.json({ ...meme });
+  } catch (err) {
+    return next(new CustomError(err.message, err.status));
+  }
 };
 
 const createMeme = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -60,8 +60,15 @@ const deleteMeme = async (req: CustomMemeRequest, res: Response, next: NextFunct
 };
 
 const getAllMemeList = async (req: Request, res: Response, next: NextFunction) => {
-  const page = parseInt(req?.params.page) || 1;
-  const size = parseInt(req?.params.size) || 10;
+  const page = parseInt(req.query.page as string) || 1;
+  if (page < 1) {
+    return next(new CustomError(`Invalid 'page' parameter`, HttpCode.BAD_REQUEST));
+  }
+
+  const size = parseInt(req.query.size as string) || 10;
+  if (size < 1) {
+    return next(new CustomError(`Invalid 'size' parameter`, HttpCode.BAD_REQUEST));
+  }
 
   try {
     const memeList = await MemeService.getAllMemeList(page, size);

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -72,10 +72,17 @@ const getAllMemeList = async (req: Request, res: Response, next: NextFunction) =
 };
 
 const getTodayMemeList = async (req: Request, res: Response, next: NextFunction) => {
-  const limit = _.get(req.body, 'limit', 5);
+  const size = parseInt(req.query.size as string) || 5;
+
+  if (size > 5) {
+    return next(
+      new CustomError(`Invalid 'size' parameter. Today Meme max size is 5.`, HttpCode.BAD_REQUEST),
+    );
+  }
+
   try {
-    const todayMemeList = await MemeService.getTodayMemeList(limit);
-    return res.json(todayMemeList);
+    const todayMemeList = await MemeService.getTodayMemeList(size);
+    return res.json({ data: todayMemeList });
   } catch (err) {
     return next(new CustomError(err.message, err.status));
   }

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -5,7 +5,7 @@ import mongoose from 'mongoose';
 import CustomError from '../errors/CustomError';
 import { HttpCode } from '../errors/HttpCode';
 import { CustomMemeRequest } from '../middleware/requestedInfo';
-import { IMeme, IMemeCreatePayload } from '../model/meme';
+import { IMemeCreatePayload } from '../model/meme';
 import * as MemeService from '../service/meme.service';
 import { logger } from '../util/logger';
 
@@ -59,7 +59,7 @@ const updateMeme = async (req: CustomMemeRequest, res: Response, next: NextFunct
   const updateInfo: IMemeCreatePayload = req.body;
 
   try {
-    const updatedMeme = await MemeService.updateMeme(meme._id, updateInfo);
+    const updatedMeme = await MemeService.updateMeme(meme._id as string, updateInfo);
     return res.json({ ...updatedMeme });
   } catch (err) {
     return next(new CustomError(err.message, err.status));
@@ -69,7 +69,7 @@ const updateMeme = async (req: CustomMemeRequest, res: Response, next: NextFunct
 const deleteMeme = async (req: CustomMemeRequest, res: Response, next: NextFunction) => {
   const meme = req.requestedMeme;
   try {
-    const deletedMeme = await MemeService.deleteMeme(meme._id);
+    const deletedMeme = await MemeService.deleteMeme(meme._id as string);
     return res.json({ result: deletedMeme });
   } catch (err) {
     return next(new CustomError(err.message, err.status));

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import _ from 'lodash';
+import mongoose from 'mongoose';
 
 import CustomError from '../errors/CustomError';
 import { HttpCode } from '../errors/HttpCode';
@@ -9,11 +10,11 @@ import * as MemeService from '../service/meme.service';
 import { logger } from '../util/logger';
 
 const getMeme = async (req: Request, res: Response, next: NextFunction) => {
-  const memeId = req.params?.memeId || req.body?.memeId || null;
 
-  const meme = await MemeService.getMeme(memeId);
-  logger.info(`Get meme - ${memeId})`);
-  return res.json({ ...meme });
+  if (!mongoose.Types.ObjectId.isValid(memeId)) {
+    return next(new CustomError(`'memeId' is not a valid ObjectId`, HttpCode.BAD_REQUEST));
+  }
+
 };
 
 const createMeme = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,18 @@
-import express, { Application, Request, Response, json, urlencoded } from 'express';
-import mongoose from 'mongoose';
-
-import router from './routes';
+import app, { connectToDatabase } from './app';
 import config from './util/config';
-import { attachRequestId, logger } from './util/logger';
+import { logger } from './util/logger';
 
-const DATABASE_URL = `${config.DB_URL}`;
+const port = config.PORT;
 
-async function startServer() {
-  const app: Application = express();
-  await mongoose.connect(DATABASE_URL);
-  logger.info('Database Connected');
+const startServer = async () => {
+  try {
+    await connectToDatabase();
+    app.listen(port, () => {
+      logger.info(`Server started on port ${port}`);
+    });
+  } catch (err) {
+    logger.error('Failed to start server', err);
+  }
+};
 
-  app.use(json());
-  app.use(urlencoded({ extended: true }));
-
-  app.get('/', (_req: Request, res: Response) => {
-    res.send('Hello PPAC');
-  });
-
-  app.use(attachRequestId);
-
-  app.use('/', router);
-
-  app.listen(3000, () => {
-    logger.info('Ready to start server');
-  });
-}
-
-setImmediate(startServer);
+startServer();

--- a/src/middleware/requestedInfo.ts
+++ b/src/middleware/requestedInfo.ts
@@ -1,13 +1,14 @@
 import { NextFunction, Request, Response } from 'express';
 import _ from 'lodash';
+import mongoose from 'mongoose';
 
 import CustomError from '../errors/CustomError';
 import { HttpCode } from '../errors/HttpCode';
-import { IMeme } from '../model/meme';
+import { IMemeDocument } from '../model/meme';
 import { getMeme } from '../service/meme.service';
 
 export interface CustomMemeRequest extends Request {
-  requestedMeme?: IMeme;
+  requestedMeme?: IMemeDocument;
 }
 
 export const getRequestedMemeInfo = async (
@@ -21,8 +22,11 @@ export const getRequestedMemeInfo = async (
     return next(new CustomError(`'memeId' should be provided`, HttpCode.BAD_REQUEST));
   }
 
-  const meme = await getMeme(memeId);
+  if (!mongoose.Types.ObjectId.isValid(memeId)) {
+    return next(new CustomError(`'memeId' is not a valid ObjectId`, HttpCode.BAD_REQUEST));
+  }
 
+  const meme = await getMeme(memeId);
   if (_.isNull(meme)) {
     return next(new CustomError(`Meme(${memeId}) does not exist`, HttpCode.NOT_FOUND));
   }

--- a/src/model/meme.ts
+++ b/src/model/meme.ts
@@ -1,14 +1,21 @@
-import mongoose, { Schema } from 'mongoose';
+import mongoose, { Schema, Document } from 'mongoose';
 
 export interface IMemeCreatePayload {
   keywords: string[];
   image: string;
-  source?: string;
+  source: string;
   isTodayMeme: boolean;
 }
 
 export interface IMeme {
-  _id: string;
+  keywords: string[];
+  image: string;
+  reaction: number;
+  source: string;
+  isTodayMeme: boolean;
+}
+
+export interface IMemeDocument extends Document {
   keywords: string[];
   image: string;
   reaction: number;
@@ -35,4 +42,4 @@ const MemeSchema: Schema = new Schema(
   },
 );
 
-export const MemeModel = mongoose.model<IMeme>('Meme', MemeSchema);
+export const MemeModel = mongoose.model<IMemeDocument>('Meme', MemeSchema);

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -9,11 +9,8 @@ import {
   getAllMemeList,
 } from '../controller/meme.controller';
 import { getRequestedMemeInfo } from '../middleware/requestedInfo';
-import { loggerMiddleware } from '../util/logger';
 
 const router = express.Router();
-
-router.use(loggerMiddleware);
 
 router.get('/list', getAllMemeList); // meme 목록 전체 조회
 router.get('/todayMeme', getTodayMemeList); // 오늘의 추천 밈 (5개)

--- a/test/meme/delete-meme.test.ts
+++ b/test/meme/delete-meme.test.ts
@@ -1,0 +1,30 @@
+import request from 'supertest';
+
+import app from '../../src/app';
+import { MemeModel } from '../../src/model/meme';
+import { createMockData } from '../util/meme.mock';
+
+let testMemeId = '';
+describe("[DELETE] '/api/meme/:memeId' ", () => {
+  beforeAll(async () => {
+    const mockDatas = createMockData(2, 0);
+    await MemeModel.insertMany(mockDatas);
+    const memeList = await MemeModel.find({});
+    testMemeId = memeList[0]._id.toString();
+  });
+
+  afterAll(async () => {
+    await MemeModel.deleteMany({});
+  });
+
+  it('should delete a meme', async () => {
+    let response = await request(app).delete(`/api/meme/${testMemeId}`);
+    expect(response.statusCode).toBe(200);
+    console.log(response.body);
+    expect(response.body.result).toBeTruthy();
+
+    response = await request(app).get(`/api/meme/list`);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data.length).toBe(1);
+  });
+});

--- a/test/meme/get-meme-list.test.ts
+++ b/test/meme/get-meme-list.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest';
+
+import app from '../../src/app';
+import { MemeModel } from '../../src/model/meme';
+import { createMockData } from '../util/meme.mock';
+
+const totalCount = 15;
+
+describe("[GET] '/api/meme/list' ", () => {
+  beforeAll(async () => {
+    const mockDatas = createMockData(totalCount, 1);
+    await MemeModel.insertMany(mockDatas);
+  });
+
+  afterAll(async () => {
+    await MemeModel.deleteMany({});
+  });
+
+  it('should return the default paginated list of memes', async () => {
+    const response = await request(app).get('/api/meme/list');
+    expect(response.statusCode).toBe(200);
+    expect(response.body.total).toBe(totalCount);
+    expect(response.body.page).toBe(1);
+    expect(response.body.totalPages).toBe(2);
+    expect(response.body.data.length).toBe(10);
+    expect(response.body.data[0]).toHaveProperty('keywords');
+    expect(response.body.data[0]).toHaveProperty('image');
+    expect(response.body.data[0]).toHaveProperty('source');
+    expect(response.body.data[0]).toHaveProperty('isTodayMeme');
+    expect(response.body.data[0]).toHaveProperty('reaction');
+  });
+
+  it('should return paginated list of memes for specific page and size', async () => {
+    const size = 5;
+    const page = 1;
+    const response = await request(app).get(`/api/meme/list?page=${page}&size=${size}`);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.total).toBe(totalCount);
+    expect(response.body.page).toBe(page);
+    expect(response.body.totalPages).toBe(3);
+    expect(response.body.data.length).toBe(size);
+  });
+
+  it('should return an error for invalid page', async () => {
+    const size = 5;
+    const page = -1;
+    const response = await request(app).get(`/api/meme/list?page=${page}&size=${size}`);
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should return an error for invalid size', async () => {
+    const size = -1;
+    const page = 3;
+    const response = await request(app).get(`/api/meme/list?page=${page}&size=${size}`);
+
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/test/meme/get-meme.test.ts
+++ b/test/meme/get-meme.test.ts
@@ -1,0 +1,31 @@
+import request from 'supertest';
+
+import app from '../../src/app';
+import { MemeModel } from '../../src/model/meme';
+import { createMockData } from '../util/meme.mock';
+
+let testMemeId = '';
+describe("[GET] '/api/meme/:memeId' ", () => {
+  beforeAll(async () => {
+    const mockDatas = createMockData(1, 0);
+    await MemeModel.insertMany(mockDatas);
+    const memeList = await MemeModel.find({});
+    testMemeId = memeList[0]._id.toString();
+  });
+
+  afterAll(async () => {
+    await MemeModel.deleteMany({});
+  });
+
+  it('should get a meme', async () => {
+    const response = await request(app).get(`/api/meme/${testMemeId}`);
+    expect(response.body._id).toBe(testMemeId);
+    expect(response.body.keywords).toStrictEqual(['k1', 'k2', 'k3']);
+    expect(response.body.isTodayMeme).toBeFalsy();
+  });
+
+  it('should not get a meme with nonexisting id', async () => {
+    const response = await request(app).get(`/api/meme/nonexistingId`);
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/test/meme/get-today-meme-list.test.ts
+++ b/test/meme/get-today-meme-list.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+
+import app from '../../src/app';
+import { MemeModel } from '../../src/model/meme';
+import { createMockData } from '../util/meme.mock';
+
+const totalCount = 10;
+
+describe("[GET] '/api/meme/todayMeme' ", () => {
+  afterEach(async () => {
+    await MemeModel.deleteMany({});
+  });
+
+  it('should return list of todayMeme - default size: 5', async () => {
+    const mockDatas = createMockData(totalCount, 5);
+    await MemeModel.insertMany(mockDatas);
+
+    const response = await request(app).get('/api/meme/todayMeme');
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data.length).toBe(5);
+  });
+
+  it('should return list of todayMeme - customize size', async () => {
+    const customizedTodayMemeCount = 3;
+    const mockDatas = createMockData(totalCount, customizedTodayMemeCount);
+    await MemeModel.insertMany(mockDatas);
+
+    const response = await request(app).get(`/api/meme/todayMeme?size=${customizedTodayMemeCount}`);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data.length).toBe(customizedTodayMemeCount);
+  });
+
+  it('should not return list of todayMeme - customize size: bigger than limit(5)', async () => {
+    const customizedTodayMemeCount = 10;
+    const mockDatas = createMockData(totalCount, customizedTodayMemeCount);
+    await MemeModel.insertMany(mockDatas);
+
+    const response = await request(app).get(`/api/meme/todayMeme?size=${customizedTodayMemeCount}`);
+
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/test/meme/patch-meme.test.ts
+++ b/test/meme/patch-meme.test.ts
@@ -1,0 +1,34 @@
+import request from 'supertest';
+
+import app from '../../src/app';
+import { IMemeCreatePayload, MemeModel } from '../../src/model/meme';
+import { createMockData } from '../util/meme.mock';
+
+let testMemeId = '';
+describe("[PATCH] '/api/meme/:memeId' ", () => {
+  beforeAll(async () => {
+    const mockDatas = createMockData(1, 0);
+    await MemeModel.insertMany(mockDatas);
+    const memeList = await MemeModel.find({});
+    testMemeId = memeList[0]._id.toString();
+  });
+
+  afterAll(async () => {
+    await MemeModel.deleteMany({});
+  });
+
+  it('should patch a meme', async () => {
+    const patchPayload: Partial<IMemeCreatePayload> = {
+      keywords: ['k2'],
+      isTodayMeme: true,
+    };
+    let response = await request(app).patch(`/api/meme/${testMemeId}`).send(patchPayload);
+    expect(response.statusCode).toBe(200);
+    expect(response.body._id).toBe(testMemeId);
+
+    response = await request(app).get(`/api/meme/${testMemeId}`);
+    expect(response.body._id).toBe(testMemeId);
+    expect(response.body.keywords).toStrictEqual(['k2']);
+    expect(response.body.isTodayMeme).toBeTruthy();
+  });
+});

--- a/test/meme/post-meme.test.ts
+++ b/test/meme/post-meme.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+
+import app from '../../src/app';
+import { IMemeCreatePayload, MemeModel } from '../../src/model/meme';
+
+describe("[POST] '/api/meme' ", () => {
+  afterAll(async () => {
+    await MemeModel.deleteMany({});
+  });
+
+  it('should create a meme', async () => {
+    const createPayload: IMemeCreatePayload = {
+      keywords: ['k1'],
+      image: 'example.com',
+      source: 'youtube',
+      isTodayMeme: false,
+    };
+    const response = await request(app).post('/api/meme').send(createPayload);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveProperty('keywords');
+    expect(response.body).toHaveProperty('image');
+    expect(response.body).toHaveProperty('source');
+    expect(response.body).toHaveProperty('isTodayMeme');
+  });
+
+  it('should not create a meme if missing required fields - keywords', async () => {
+    const missingPayload = {
+      image: 'example.com',
+      source: 'youtube',
+    };
+    const response = await request(app).post('/api/meme').send(missingPayload);
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should not create a meme if missing required fields - image', async () => {
+    const missingPayload = {
+      keywords: ['k1'],
+      source: 'youtube',
+    };
+    const response = await request(app).post('/api/meme').send(missingPayload);
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should not create a meme if missing required fields - source', async () => {
+    const missingPayload = {
+      keywords: ['k1'],
+      image: 'example.com',
+    };
+    const response = await request(app).post('/api/meme').send(missingPayload);
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,15 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});

--- a/test/util/meme.mock.ts
+++ b/test/util/meme.mock.ts
@@ -1,0 +1,31 @@
+import { IMeme } from '../../src/model/meme';
+
+const memeMockData: IMeme = {
+  keywords: ['k1', 'k2', 'k3'],
+  image: 'example.com',
+  source: 'youtube',
+  isTodayMeme: false,
+  reaction: 0,
+};
+
+const createMockData = (size: number, todayMemeCount: number): IMeme[] => {
+  const result: IMeme[] = [];
+
+  for (let i = 0; i < size; i++) {
+    const mockData = { ...memeMockData };
+
+    if (i < todayMemeCount) {
+      mockData.isTodayMeme = true;
+    } else {
+      mockData.isTodayMeme = false;
+    }
+
+    mockData.reaction = Math.floor(Math.random() * 51);
+
+    result.push(mockData);
+  }
+
+  return result;
+};
+
+export { createMockData };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "include": ["src/custom.d.ts", "src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts"],
+  "include": ["src/custom.d.ts", "src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"],
   "files": ["src/custom.d.ts"],
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "CommonJS",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
@@ -14,6 +14,6 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "skipLibCheck": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
- 패키지명 수정
- `startServer` 구조 수정
  - 테스트코드에서 `supertest`로 `app`을 쓰기 위함
- 타입 수정 
  - `IMeme`: 애플리케이션 로직에 사용할 data 타입
  - `IMemeDocument` : MongoDB Documet 타입
  - `IMeme.source`: 필수 필드로 변경
- API 수정
  - 밈 1개 조회: 찾지 못했을 때에 대한 예외처리
  - 밈 목록 조회, 오늘의 밈 조회: query parameter로 수정, 예외처리 추가
