### PR TITLE
스웨거 문서 수정 / 인기 키워드 조회 버그 수정

### DIFF
--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -147,7 +147,10 @@ const getTodayMemeList = async (req: Request, res: Response, next: NextFunction)
 
   if (size > 5) {
     return next(
-      new CustomError(`Invalid 'size' parameter. Today Meme max size is 5.`, HttpCode.BAD_REQUEST),
+      new CustomError(
+        `Invalid 'size' parameter. Today Meme List max size is 5.`,
+        HttpCode.BAD_REQUEST,
+      ),
     );
   }
 

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import _ from 'lodash';
-import mongoose from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 
 import CustomError from '../errors/CustomError';
 import { HttpCode } from '../errors/HttpCode';
@@ -81,8 +81,13 @@ const createMeme = async (req: Request, res: Response, next: NextFunction) => {
     return next(new CustomError(`'keywordIds' field should be provided`, HttpCode.BAD_REQUEST));
   }
 
+  const createPayload: IMemeCreatePayload = {
+    ...req.body,
+    keywordIds: req.body.keywordIds.map((id: string) => new Types.ObjectId(id)),
+  };
+
   try {
-    const meme = await MemeService.createMeme(req.body as IMemeCreatePayload);
+    const meme = await MemeService.createMeme(createPayload);
     return res.json(createSuccessResponse(HttpCode.CREATED, 'Create Meme', meme));
   } catch (err) {
     return next(new CustomError(err.message, err.status));
@@ -91,10 +96,14 @@ const createMeme = async (req: Request, res: Response, next: NextFunction) => {
 
 const updateMeme = async (req: CustomRequest, res: Response, next: NextFunction) => {
   const meme = req.requestedMeme;
-  const updateInfo: IMemeUpdatePayload = req.body;
+
+  const updatePayload: IMemeUpdatePayload = {
+    ...req.body,
+    keywordIds: req.body.keywordIds.map((id: string) => new Types.ObjectId(id)),
+  };
 
   try {
-    const updatedMeme = await MemeService.updateMeme(meme._id, updateInfo);
+    const updatedMeme = await MemeService.updateMeme(meme._id, updatePayload);
     return res.json(createSuccessResponse(HttpCode.OK, 'Updated Meme', updatedMeme));
   } catch (err) {
     return next(new CustomError(err.message, err.status));

--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -1,9 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
 import _ from 'lodash';
-import { CustomRequest } from '../middleware/requestedInfo';
 
 import CustomError from '../errors/CustomError';
 import { HttpCode } from '../errors/HttpCode';
+import { CustomRequest } from '../middleware/requestedInfo';
 import { InteractionType, MemeInteractionModel } from '../model/memeInteraction';
 import * as UserService from '../service/user.service';
 import { createSuccessResponse } from '../util/response';

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,8 +5,11 @@ import keywordCategory from './keywordCategory';
 import meme from './meme';
 import user from './user';
 import { errorHandler } from '../middleware/errorHandler';
+import { loggerMiddleware } from '../util/logger';
 
 const router = express.Router();
+
+router.use(loggerMiddleware);
 
 router.use('/api/meme', meme);
 router.use('/api/user', user);

--- a/src/routes/keyword.ts
+++ b/src/routes/keyword.ts
@@ -10,7 +10,6 @@ import {
 } from '../controller/keyword.controller';
 import { validateCategory, validateKeywordDulication } from '../middleware/duplicateValidator';
 import { getKeywordInfoByName, getKeywordInfoById } from '../middleware/requestedInfo';
-import { loggerMiddleware } from '../util/logger';
 
 const router = express.Router();
 
@@ -19,7 +18,7 @@ const router = express.Router();
  * /api/keyword:
  *   post:
  *     tags: [Keyword]
- *     summary: 키워드 생성
+ *     summary: 키워드 생성 (백오피스)
  *     description: 키워드를 생성한다.
  *     requestBody:
  *       required: true
@@ -31,7 +30,7 @@ const router = express.Router();
  *               category:
  *                 type: string
  *                 example: "감정"
- *               keyword:
+ *               name:
  *                 type: string
  *                 example: "웃긴"
  *     responses:
@@ -87,7 +86,7 @@ router.post('/', validateCategory, validateKeywordDulication, createKeyword);
  * /api/keyword/{keywordId}:
  *   put:
  *     tags: [Keyword]
- *     summary: 키워드 업데이트
+ *     summary: 키워드 업데이트 (백오피스)
  *     description: 키워드 정보를 업데이트한다.
  *     parameters:
  *       - in: path
@@ -177,18 +176,18 @@ router.put('/:keywordId', getKeywordInfoById, updateKeyword);
  * /api/keyword/{keywordId}:
  *   delete:
  *     tags: [Keyword]
- *     summary: 키워드 삭제
- *     description: 키워드를 삭제한다.
+ *     summary: 키워드 삭제 (백오피스)
+ *     description: 키워드를 삭제한다. (백오피스)
  *     parameters:
  *       - in: path
  *         name: keywordId
  *         required: true
- *         description: 키워드 id
+ *         description: 삭제할 키워드 id
  *         schema:
  *           type: string
  *     responses:
  *       200:
- *         description: Successfully deleted the keyword
+ *         description: 키워드 삭제 성공
  *         content:
  *           application/json:
  *             schema:
@@ -259,16 +258,28 @@ router.delete('/:keywordId', getKeywordInfoById, deleteKeyword);
  *                     properties:
  *                       _id:
  *                         type: string
- *                         example: "6096237971f57915779c1417"
- *                       keyword:
+ *                         example: "66880f7ee341b999bc14e896"
+ *                       name:
  *                         type: string
- *                         example: "cute"
+ *                         example: "행복"
+ *                       category:
+ *                         type: string
+ *                         example: "감정"
  *                       searchCount:
  *                         type: integer
- *                         example: 10
+ *                         example: 100
  *                       topReactionImage:
  *                         type: string
  *                         example: "https://example.com/top-reaction-image.jpg"
+ *                       isDeleted:
+ *                         type: boolean
+ *                         example: false
+ *                       createdAt:
+ *                         type: string
+ *                         example: "2024-07-05T15:21:34.012Z"
+ *                       updatedAt:
+ *                         type: string
+ *                         example: "2024-07-05T16:03:22.057Z"
  *       400:
  *         description: Invalid query parameter
  *         content:
@@ -326,7 +337,7 @@ router.get('/top', getTopKeywords);
  *             properties:
  *               name:
  *                 type: string
- *                 example: "cute"
+ *                 example: "슬픈"
  *     responses:
  *       200:
  *         description: Successfully updated keyword search count
@@ -351,16 +362,25 @@ router.get('/top', getTopKeywords);
  *                     properties:
  *                       _id:
  *                         type: string
- *                         example: "6096237971f57915779c1417"
- *                       keyword:
+ *                         example: "66880f7ee341b999bc14e896"
+ *                       name:
  *                         type: string
- *                         example: "cute"
+ *                         example: "긁"
+ *                       category:
+ *                         type: string
+ *                         example: "상황"
  *                       searchCount:
  *                         type: integer
- *                         example: 11
- *                       topReactionImage:
+ *                         example: 1
+ *                       isDeleted:
+ *                         type: boolean
+ *                         example: false
+ *                       createdAt:
  *                         type: string
- *                         example: "https://example.com/top-reaction-image.jpg"
+ *                         example: "2024-07-05T15:21:34.012Z"
+ *                       updatedAt:
+ *                         type: string
+ *                         example: "2024-07-05T16:03:22.057Z"
  *       400:
  *         description: 잘못된 요청
  *         content:
@@ -407,8 +427,8 @@ router.patch('/count', getKeywordInfoByName, increaseSearchCount);
  * /api/keyword/recommend:
  *   get:
  *     tags: [Keyword]
- *     summary: 추천 키워드 조회
- *     description: 추천 키워드를 조회합니다.
+ *     summary: 무슨 밈 찾아? 키워드 카테고리, 키워드 목록
+ *     description: 무슨 밈 찾아? 키워드 카테고리, 키워드 목록 출력
  *     responses:
  *       200:
  *         description: 추천 키워드 목록
@@ -429,11 +449,21 @@ router.patch('/count', getKeywordInfoByName, increaseSearchCount);
  *                 data:
  *                   type: object
  *                   properties:
- *                     categories:
+ *                     감정:
  *                       type: array
- *                       items:
- *                         type: string
- *                         example: "test1"
+ *                       example:
+ *                         - "행복"
+ *                         - "슬픈"
+ *                         - "분노"
+ *                         - "웃긴"
+ *                         - "피곤"
+ *                     상황:
+ *                       type: array
+ *                       example:
+ *                         - "회사"
+ *                         - "대학"
+ *                         - "공부"
+ *                         - "긁"
  *       500:
  *         description: Internal server error
  *         content:

--- a/src/routes/keyword.ts
+++ b/src/routes/keyword.ts
@@ -14,8 +14,6 @@ import { loggerMiddleware } from '../util/logger';
 
 const router = express.Router();
 
-router.use(loggerMiddleware);
-
 /**
  * @swagger
  * /api/keyword:

--- a/src/routes/keywordCategory.ts
+++ b/src/routes/keywordCategory.ts
@@ -96,6 +96,9 @@ const router = express.Router();
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.post('/', validateCategoryDuplication, createKeywordCategory);
 
@@ -167,6 +170,9 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                 message:
  *                   type: string
  *                   example: field should be provided
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -256,6 +262,9 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                 message:
  *                   type: string
  *                   example: field should be provided
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -272,6 +281,9 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  *   delete:
  *     tags: [KeywordCategory]
  *     summary: 키워드 카테고리 삭제
@@ -319,6 +331,9 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                 message:
  *                   type: string
  *                   example: Cannot find KeywordCategory
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -335,6 +350,9 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.get('/:categoryName', getRequestedKeywordCategoryInfo, getKeywordCategory);
 router.put('/:categoryName', getRequestedKeywordCategoryInfo, updateKeywordCategory);

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -130,6 +130,9 @@ const router = express.Router();
  *                 message:
  *                   type: string
  *                   example: Invalid 'page' parameter
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       '500':
  *         description: Internal server error
  *         content:
@@ -146,6 +149,9 @@ const router = express.Router();
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.get('/list', getAllMemeList); // meme 목록 전체 조회
 
@@ -239,6 +245,9 @@ router.get('/list', getAllMemeList); // meme 목록 전체 조회
  *                 message:
  *                   type: string
  *                   example: Invalid 'size' parameter. Today Meme max size is 5.
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -255,6 +264,9 @@ router.get('/list', getAllMemeList); // meme 목록 전체 조회
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.get('/todayMeme', getTodayMemeList); // 오늘의 추천 밈 (5개)
 
@@ -370,6 +382,9 @@ router.get('/todayMeme', getTodayMemeList); // 오늘의 추천 밈 (5개)
  *                 message:
  *                   type: string
  *                   example: title field should be provided
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -386,6 +401,9 @@ router.get('/todayMeme', getTodayMemeList); // 오늘의 추천 밈 (5개)
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.post('/', createMeme); // meme 생성
 
@@ -476,6 +494,9 @@ router.post('/', createMeme); // meme 생성
  *                 message:
  *                   type: string
  *                   example: 'memeId field should be provided'
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       404:
  *         description: Meme not found
  *         content:
@@ -492,6 +513,9 @@ router.post('/', createMeme); // meme 생성
  *                 message:
  *                   type: string
  *                   example: 'Meme(memeId) not found.'
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal Server Error
  *         content:
@@ -508,6 +532,9 @@ router.post('/', createMeme); // meme 생성
  *                 message:
  *                   type: string
  *                   example: 'Internal Server Error'
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.get('/:memeId', getMemeWithKeywords); // meme 조회
 
@@ -630,6 +657,9 @@ router.get('/:memeId', getMemeWithKeywords); // meme 조회
  *                 message:
  *                   type: string
  *                   example: Invalid 'memeId' parameter
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       404:
  *         description: Meme not found
  *         content:
@@ -646,6 +676,9 @@ router.get('/:memeId', getMemeWithKeywords); // meme 조회
  *                 message:
  *                   type: string
  *                   example: Meme (6686b064aa47d3ef168cd078) not found
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -662,6 +695,9 @@ router.get('/:memeId', getMemeWithKeywords); // meme 조회
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.patch('/:memeId', getRequestedMemeInfo, updateMeme); // meme 수정
 
@@ -730,6 +766,9 @@ router.patch('/:memeId', getRequestedMemeInfo, updateMeme); // meme 수정
  *                 message:
  *                   type: string
  *                   example: Meme(66805b1372ef94c9c0ba1349) does not exist
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -746,6 +785,9 @@ router.patch('/:memeId', getRequestedMemeInfo, updateMeme); // meme 수정
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
 
@@ -807,6 +849,9 @@ router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
  *                 message:
  *                   type: string
  *                   example: 'deviceId should be provided'
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       404:
  *         description: Meme or user not found
  *         content:
@@ -823,6 +868,9 @@ router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
  *                 message:
  *                   type: string
  *                   example: Meme(66805b1372ef94c9c0ba1349) does not exist
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -839,6 +887,9 @@ router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createMemeSave);
 
@@ -900,6 +951,9 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  *                 message:
  *                   type: string
  *                   example: 'deviceId should be provided'
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       404:
  *         description: Meme or user not found
  *         content:
@@ -916,6 +970,9 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  *                 message:
  *                   type: string
  *                   example: Meme(66805b1372ef94c9c0ba1349) does not exist
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -932,6 +989,9 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, createMemeShare);
 
@@ -1005,6 +1065,9 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  *                 message:
  *                   type: string
  *                   example: Invalid 'type' parameter.
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       404:
  *         description: Meme or user not found
  *         content:
@@ -1021,6 +1084,9 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  *                 message:
  *                   type: string
  *                   example: Meme(66805b1372ef94c9c0ba1349) does not exist
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -1037,6 +1103,9 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, createMemeWatch);
 
@@ -1115,6 +1184,9 @@ router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, 
  *                 message:
  *                   type: string
  *                   example: Meme (6686b064aa47d3ef168cd078) or user not found
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -1131,6 +1203,9 @@ router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, 
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, createMemeReaction);
 
@@ -1249,6 +1324,9 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  *                 message:
  *                   type: string
  *                   example: Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.get('/search/:name', getKeywordInfoByName, searchMemeByKeyword);
 

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -27,11 +27,24 @@ const router = express.Router();
  *   get:
  *     tags:
  *       - Meme
- *     summary: Get all meme
- *     description: Retrieve a list of all memes
+ *     summary: 밈 전체 목록 조회
+ *     description: 밈 전체 목록 조회
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: number
+ *           example: 1
+ *           description: 현재 페이지 번호 (기본값 1)
+ *       - in: query
+ *         name: size
+ *         schema:
+ *           type: number
+ *           example: 10
+ *           description: 한 번에 조회할 밈 개수 (기본값 10)
  *     responses:
  *       '200':
- *         description: A list of memes
+ *         description: 밈 목록
  *         content:
  *           application/json:
  *             schema:
@@ -45,7 +58,7 @@ const router = express.Router();
  *                   example: 200
  *                 message:
  *                   type: string
- *                   example: Get all meme list
+ *                   example: 밈 전체 목록 조회
  *                 data:
  *                   type: object
  *                   properties:
@@ -141,11 +154,22 @@ router.get('/list', getAllMemeList); // meme 목록 전체 조회
  * /api/meme/todayMeme:
  *   get:
  *     tags: [Meme]
- *     summary: Get today's meme list
- *     description: Get a list of today's 6 memes
+ *     summary: 추천 밈 정보 조회
+ *     description: 추천 밈 목록을 조회한다. (현재는 주 단위, 추후 일 단위로 변경될 수 있음)
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               size:
+ *                 type: number
+ *                 example: 5
+ *                 description: 추천 밈 개수 / 기본값 5, body를 넘기지않으면 자동으로 서버에서 5로 설정 후 5개 조회
  *     responses:
  *       200:
- *         description: Get a list of today's 6 memes
+ *         description: 추천 밈 목록 조회 성공
  *         content:
  *           application/json:
  *             schema:
@@ -239,8 +263,8 @@ router.get('/todayMeme', getTodayMemeList); // 오늘의 추천 밈 (5개)
  * /api/meme:
  *   post:
  *     tags: [Meme]
- *     summary: Create a new meme
- *     description: Create a new meme with title, image, source, and keywordIds
+ *     summary: 밈 생성 (백오피스)
+ *     description: 밈을 생성한다. (백오피스)
  *     requestBody:
  *       required: true
  *       content:
@@ -250,25 +274,25 @@ router.get('/todayMeme', getTodayMemeList); // 오늘의 추천 밈 (5개)
  *             properties:
  *               title:
  *                 type: string
- *                 example: "Funny Meme"
- *                 description: The title of the meme
+ *                 example: "무한도전 정총무"
+ *                 description: 밈 제목
  *               image:
  *                 type: string
  *                 example: "https://example.com/meme.jpg"
- *                 description: URL of the meme image
+ *                 description: 밈 이미지 주소
  *               source:
  *                 type: string
- *                 example: "Internet"
- *                 description: Source of the meme
+ *                 example: "무한도전 102화"
+ *                 description: 밈 출처
  *               keywordIds:
  *                 type: array
  *                 items:
  *                   type: string
  *                   example: "667fee6dc58681a42d57dc37"
- *                   description: Array of keyword IDs associated with the meme
+ *                   description: 밈의 키워드 id 목록
  *     responses:
  *       201:
- *         description: The created meme
+ *         description: 생성된 밈 정보
  *         content:
  *           application/json:
  *             schema:
@@ -286,52 +310,52 @@ router.get('/todayMeme', getTodayMemeList); // 오늘의 추천 밈 (5개)
  *                 data:
  *                   type: object
  *                   properties:
+ *                     _id:
+ *                       type: string
+ *                       example: "6686af56f7c49ec21e3ef1c1"
+ *                       description: 밈 id
  *                     title:
  *                       type: string
- *                       example: "Funny Meme"
- *                       description: The title of the meme
+ *                       example: "무한도전 정총무"
+ *                       description: 밈 제목
  *                     image:
  *                       type: string
  *                       example: "https://example.com/meme.jpg"
- *                       description: URL of the meme image
+ *                       description: 밈 이미지 주소
  *                     source:
  *                       type: string
- *                       example: "Internet"
- *                       description: Source of the meme
+ *                       example: "무한도전 102화"
+ *                       description: 밈 출처
  *                     keywordIds:
  *                       type: array
  *                       items:
  *                         type: string
  *                         example: "667fee6dc58681a42d57dc37"
- *                         description: Array of keyword IDs associated with the meme
+ *                         description: 밈의 키워드 id 목록
  *                     reaction:
  *                       type: integer
  *                       example: 0
- *                       description: Number of reactions for the meme
+ *                       description: ㅋㅋㅋ 리액션 수 (생성 시 기본값 0)
  *                     isTodayMeme:
  *                       type: boolean
  *                       example: false
- *                       description: Indicates if the meme is for today
+ *                       description: 추천 밈 여부
  *                     isDeleted:
  *                       type: boolean
  *                       example: false
- *                       description: Indicates if the meme is deleted
- *                     _id:
- *                       type: string
- *                       example: "6686af56f7c49ec21e3ef1c1"
- *                       description: The ID of the created meme
+ *                       description: 밈 삭제 여부
  *                     createdAt:
  *                       type: string
  *                       format: date-time
  *                       example: "2024-07-04T14:19:02.918Z"
- *                       description: Timestamp when the meme was created
+ *                       description: 생성 시각
  *                     updatedAt:
  *                       type: string
  *                       format: date-time
  *                       example: "2024-07-04T14:19:02.918Z"
- *                       description: Timestamp when the meme was last updated
+ *                       description: 업데이트 시각
  *       400:
- *         description: Invalid request body or missing required fields
+ *         description: 잘못된 요청 - requestBody 형식 확인 필요
  *         content:
  *           application/json:
  *             schema:
@@ -370,15 +394,15 @@ router.post('/', createMeme); // meme 생성
  * /api/meme/{memeId}:
  *   get:
  *     tags: [Meme]
- *     summary: get memeInfo with keywords
- *     description: get memeInfo with keywords
+ *     summary: 밈 정보 조회(키워드 포함)
+ *     description: 밈 정보를 조회한다. 밈의 키워드 정보도 함께 포함한다. 이때 키워드는 키워드명만 제공된다 (키워드의 개별 정보 X)
  *     parameters:
  *     - in: path
  *       name: memeId
  *       required: true
  *       schema:
  *         type: string
- *       description: The ID of the meme
+ *       description: 밈 ID
  *     responses:
  *       200:
  *         description: The meme
@@ -404,16 +428,16 @@ router.post('/', createMeme); // meme 생성
  *                       example: "66805b1372ef94c9c0ba1349"
  *                     title:
  *                       type: string
- *                       example: "title1"
+ *                       example: "무한도전 정총무"
  *                     image:
  *                       type: string
- *                       example: "image1"
+ *                       example: "https://example.com/meme.jpg"
  *                     reaction:
  *                       type: integer
  *                       example: 0
  *                     source:
  *                       type: string
- *                       example: "source1"
+ *                       example: "무한도전 102화"
  *                     isTodayMeme:
  *                       type: boolean
  *                       example: false
@@ -432,7 +456,10 @@ router.post('/', createMeme); // meme 생성
  *                       type: array
  *                       items:
  *                         type: string
- *                         example: "angry"
+ *                         example:
+ *                           - "무한상사"
+ *                           - "정총무"
+ *                           - "전자두뇌"
  *       400:
  *         description: Bad Request
  *         content:
@@ -483,20 +510,21 @@ router.post('/', createMeme); // meme 생성
  *                   example: 'Internal Server Error'
  */
 router.get('/:memeId', getMemeWithKeywords); // meme 조회
+
 /**
  * @swagger
  * /api/meme/{memeId}:
  *   patch:
  *     tags: [Meme]
- *     summary: Update a meme
- *     description: Update a meme with the specified memeId
+ *     summary: 밈 수정(백오피스)
+ *     description: 밈을 수정한다 (백오피스)
  *     parameters:
  *     - in: path
  *       name: memeId
  *       schema:
  *         type: string
  *       required: true
- *       description: The ID of the meme to update
+ *       description: 수정할 밈 id
  *     requestBody:
  *       required: true
  *       content:
@@ -506,17 +534,25 @@ router.get('/:memeId', getMemeWithKeywords); // meme 조회
  *             properties:
  *               title:
  *                 type: string
+ *                 example: "무한도전 정총무 2탄"
+ *                 description: 밈 제목
  *               image:
  *                 type: string
+ *                 example: "https://example.com/meme.jpg"
+ *                 description: 밈 이미지 주소
  *               source:
  *                 type: string
+ *                 example: "무한도전 103화"
+ *                 description: 밈 출처
  *               keywordIds:
  *                 type: array
  *                 items:
  *                   type: string
+ *                   example: "667fee6dc58681a42d57dc37"
+ *                   description: 밈의 키워드 id 목록
  *     responses:
  *       200:
- *         description: Updated Meme
+ *         description: 수정된 밈 정보
  *         content:
  *           application/json:
  *             schema:
@@ -537,37 +573,37 @@ router.get('/:memeId', getMemeWithKeywords); // meme 조회
  *                     _id:
  *                       type: string
  *                       example: "6686b064aa47d3ef168cd078"
- *                       description: The ID of the updated meme
+ *                       description: 밈 id
  *                     title:
  *                       type: string
- *                       example: "title5"
- *                       description: The updated title of the meme
+ *                       example: "무한도전 정총무"
+ *                       description: 밈 제목
+ *                     image:
+ *                       type: string
+ *                       example: "https://example.com/meme.jpg"
+ *                       description: 밈 이미지 주소
+ *                     source:
+ *                       type: string
+ *                       example: "source5"
+ *                       description: The updated source of the meme
  *                     keywordIds:
  *                       type: array
  *                       items:
  *                         type: string
  *                         example: "667fee7ac58681a42d57dc3b"
- *                         description: Array of updated keyword IDs associated with the meme
- *                     image:
- *                       type: string
- *                       example: "image5"
- *                       description: The updated URL of the meme image
+ *                         description: 밈의 키워드 id 목록
  *                     reaction:
  *                       type: integer
  *                       example: 0
- *                       description: The updated number of reactions for the meme
- *                     source:
- *                       type: string
- *                       example: "source5"
- *                       description: The updated source of the meme
+ *                       description: ㅋㅋㅋ 리액션 수 (생성 시 기본값 0)
  *                     isTodayMeme:
  *                       type: boolean
  *                       example: true
- *                       description: Updated flag indicating if the meme is for today
+ *                       description: 추천 밈 여부
  *                     isDeleted:
  *                       type: boolean
  *                       example: false
- *                       description: Updated flag indicating if the meme is deleted
+ *                       description: 밈 삭제 여부
  *                     createdAt:
  *                       type: string
  *                       format: date-time
@@ -579,7 +615,7 @@ router.get('/:memeId', getMemeWithKeywords); // meme 조회
  *                       example: "2024-07-04T15:15:06.833Z"
  *                       description: Timestamp when the meme was last updated
  *       400:
- *         description: Invalid memeId or request body
+ *         description: 잘못된 요청
  *         content:
  *           application/json:
  *             schema:
@@ -634,8 +670,8 @@ router.patch('/:memeId', getRequestedMemeInfo, updateMeme); // meme 수정
  * /api/meme/{memeId}:
  *   delete:
  *     tags: [Meme]
- *     summary: Delete a meme
- *     description: Delete a meme with the specified memeId
+ *     summary: 밈 삭제(백오피스)
+ *     description: 밈을 삭제한다.
  *     parameters:
  *     - in: path
  *       name: memeId
@@ -718,14 +754,14 @@ router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
  * /api/meme/{memeId}/save:
  *   post:
  *     tags: [Meme]
- *     summary: Save a meme for the user
- *     description: Save a meme for the user
+ *     summary: 밈 저장 (내 파밈함에 보관됨)
+ *     description: 밈을 저장한다. 저장한 밈은 내 파밈함에 보관된다.
  *     parameters:
  *     - in: path
  *       name: memeId
  *       schema:
  *         type: string
- *       description: The ID of the meme to save
+ *       description: 저장할 밈 id
  *     requestBody:
  *       required: true
  *       content:
@@ -811,14 +847,14 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  * /api/meme/{memeId}/share:
  *   post:
  *     tags: [Meme]
- *     summary: Share a meme
- *     description: Share a meme by the user
+ *     summary: 밈 공유
+ *     description: 밈 공유할 때 사용되는 api로 '밈 공유' 카운트를 올린다.
  *     parameters:
  *     - in: path
  *       name: memeId
  *       schema:
  *         type: string
- *       description: The ID of the meme to share
+ *       description: 공유할 밈 id
  *     requestBody:
  *       required: true
  *       content:
@@ -904,20 +940,20 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  * /api/meme/{memeId}/watch/{type}:
  *   post:
  *     tags: [Meme]
- *     summary: Watch a meme
- *     description: Record a user interaction with a meme (e.g., search or recommendation).
+ *     summary: 밈 보기 (밈의 타입 필요)
+ *     description: 사용자가 밈을 볼 때 사용되는 api로 '밈 보기' 카운트를 올린다. 밈의 타입을 적어줘야한다.
  *     parameters:
  *     - in: path
  *       name: memeId
  *       schema:
  *         type: string
- *       description: The ID of the meme to watch
+ *       description: 밈 id
  *     - in: path
  *       name: type
  *       schema:
  *         type: string
  *       enum: [search, recommend]
- *       description: The type of watch interaction (search or recommend)
+ *       description: 밈 종류 (search - 검색으로 조회된 밈 / recommend - 추천 탭에서 조회된 밈)
  *     requestBody:
  *       required: true
  *       content:
@@ -944,15 +980,15 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  *                   example: 201
  *                 message:
  *                   type: string
- *                   example: Create Meme Watch or recommend Meme Watch
+ *                   example: Create Meme Watch 혹은 recommend Meme Watch
  *                 data:
  *                   oneOf:
  *                     - type: boolean
  *                       example: true
- *                       description: Returned when type is 'search'
+ *                       description: search 타입의 밈인 경우 밈 카운트 증가 성공 여부
  *                     - type: integer
  *                       example: 1
- *                       description: Returned when type is 'recommend'
+ *                       description: recommend 타입의 밈인 경우 추천 밈 조회 개수
  *       400:
  *         description: Invalid parameters or type
  *         content:
@@ -1009,15 +1045,15 @@ router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, 
  * /api/meme/{memeId}/reaction:
  *   post:
  *     tags: [Meme]
- *     summary: Create a reaction for a meme
- *     description: Create a reaction (e.g., like) for the specified meme
+ *     summary: 밈 리액션(ㅋㅋㅋ)
+ *     description: 밈 리액션 시 사용되는 api로 'ㅋ 남기기' 카운트를 올린다.
  *     parameters:
  *     - in: path
  *       name: memeId
  *       schema:
  *         type: string
  *       required: true
- *       description: The ID of the meme to react to
+ *       description: 리액션할 밈 id
  *     requestBody:
  *       required: true
  *       content:
@@ -1027,7 +1063,6 @@ router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, 
  *             properties:
  *               deviceId:
  *                 type: string
- *                 description: The ID of the device/user reacting to the meme
  *     responses:
  *       201:
  *         description: Created Meme Reaction
@@ -1104,18 +1139,19 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  * /api/meme/search/{name}:
  *   get:
  *     tags: [Meme]
- *     summary: Search memes by keyword
- *     description: Retrieve memes associated with a specific keyword
+ *     summary: 키워드에 해당하는 밈 조회
+ *     description: 키워드 클릭 시 해당 키워드를 포함한 밈을 조회하고 목록을 반환한다.
  *     parameters:
  *     - in: path
  *       name: name
  *       schema:
  *         type: string
+ *         example: "행복"
  *       required: true
- *       description: The name of the keyword to search for
+ *       description: 키워드명
  *     responses:
  *       200:
- *         description: A list of memes associated with the keyword
+ *         description: 키워드를 포함한 밈 목록
  *         content:
  *           application/json:
  *             schema:
@@ -1140,7 +1176,7 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  *                         example: "6686b075aa47d3ef168cd07e"
  *                       title:
  *                         type: string
- *                         example: "title5"
+ *                         example: "완전 럭키비키자나~"
  *                       keywordIds:
  *                         type: array
  *                         items:
@@ -1148,25 +1184,39 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  *                           properties:
  *                             _id:
  *                               type: string
- *                               example: "667fee7ac58681a42d57dc3b"
+ *                               example:
+ *                                - "667fee7ac58681a42d57dc3b"
+ *                                - "667fee7ac58681a42d57dc3d"
+ *                                - "667fee7ac58681a42d57dc3v"
  *                             name:
  *                               type: string
- *                               example: "pig"
+ *                               example:
+ *                                - "행복"
+ *                                - "장원영"
+ *                                - "럭키비키"
  *                       image:
  *                         type: string
- *                         example: "image5"
+ *                         example: "https://example.com/meme.jpg"
  *                       reaction:
  *                         type: integer
  *                         example: 0
  *                       source:
  *                         type: string
- *                         example: "source5"
+ *                         example: "유투브"
  *                       isTodayMeme:
  *                         type: boolean
  *                         example: true
  *                       isDeleted:
  *                         type: boolean
  *                         example: false
+ *                       createdAt:
+ *                         type: string
+ *                         format: date-time
+ *                         example: "2024-06-29T19:05:55.638Z"
+ *                       updatedAt:
+ *                         type: string
+ *                         format: date-time
+ *                         example: "2024-06-29T19:05:55.638Z"
  *       400:
  *         description: Invalid keyword name
  *         content:

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -804,7 +804,7 @@ router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
  *                   type: string
  *                   example: Internal server error
  */
-router.post('/:memeId/save', getRequestedMemeInfo, getRequestedUserInfo, createMemeSave);
+router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createMemeSave);
 
 /**
  * @swagger
@@ -897,7 +897,7 @@ router.post('/:memeId/save', getRequestedMemeInfo, getRequestedUserInfo, createM
  *                   type: string
  *                   example: Internal server error
  */
-router.post('/:memeId/share', getRequestedMemeInfo, getRequestedUserInfo, createMemeShare);
+router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, createMemeShare);
 
 /**
  * @swagger
@@ -1002,7 +1002,8 @@ router.post('/:memeId/share', getRequestedMemeInfo, getRequestedUserInfo, create
  *                   type: string
  *                   example: Internal server error
  */
-router.post('/:memeId/watch/:type', getRequestedMemeInfo, getRequestedUserInfo, createMemeWatch);
+router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, createMemeWatch);
+
 /**
  * @swagger
  * /api/meme/{memeId}/reaction:
@@ -1096,7 +1097,7 @@ router.post('/:memeId/watch/:type', getRequestedMemeInfo, getRequestedUserInfo, 
  *                   type: string
  *                   example: Internal server error
  */
-router.post('/:memeId/reaction', getRequestedMemeInfo, getRequestedUserInfo, createMemeReaction);
+router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, createMemeReaction);
 
 /**
  * @swagger

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -85,6 +85,9 @@ const router = express.Router();
  *                  message:
  *                    type: string
  *                    example: deviceId' field should be provided
+ *                 data:
+ *                   type: null
+ *                   example: null
  *        500:
  *          description: Internal server error
  *          content:
@@ -102,6 +105,9 @@ const router = express.Router();
  *                    type: string
  *                    example:
  *                      Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.post('/', UserController.createUser); // user 생성
 
@@ -186,6 +192,9 @@ router.post('/', UserController.createUser); // user 생성
  *                 message:
  *                   type: string
  *                   example: deviceID should be provided
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 조회
 
@@ -249,6 +258,9 @@ router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 
  *                 message:
  *                   type: string
  *                   example: deviceID should be provided
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -266,7 +278,9 @@ router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 
  *                   type: string
  *                   example:
  *                     - Internal server error
- *
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.get('/:deviceId/save', getRequestedUserInfo, UserController.getSavedMeme); // user가 저장한 meme 조회
 
@@ -330,6 +344,9 @@ router.get('/:deviceId/save', getRequestedUserInfo, UserController.getSavedMeme)
  *                 message:
  *                   type: string
  *                   example: deviceID should be provided
+ *                 data:
+ *                   type: null
+ *                   example: null
  *       500:
  *         description: Internal server error
  *         content:
@@ -347,6 +364,9 @@ router.get('/:deviceId/save', getRequestedUserInfo, UserController.getSavedMeme)
  *                   type: string
  *                   example:
  *                     - Internal server error
+ *                 data:
+ *                   type: null
+ *                   example: null
  */
 router.get('/:deviceId/lastSeenMeme', getRequestedUserInfo, UserController.getLastSeenMeme);
 

--- a/src/service/meme.service.ts
+++ b/src/service/meme.service.ts
@@ -252,7 +252,9 @@ async function deleteMemeSave(user: IUserDocument, meme: IMemeDocument): Promise
 }
 async function getTopReactionImage(keyword: IKeywordDocument): Promise<string> {
   try {
-    const topReactionMeme = await MemeModel.findOne({ keywordIds: keyword._id }).sort({
+    const topReactionMeme: IMemeDocument = await MemeModel.findOne({
+      keywordIds: { $in: [keyword._id] },
+    }).sort({
       reaction: -1,
     });
 


### PR DESCRIPTION
## 개선
- 모든 라우트에 loggerMiddleware 적용
- Meme 라우터에서 UserMiddleware 우선 통과하도록 변경 (user -> meme  validation)
- swagger 개선
  - 자동 생성으로 잘못 들어간 필드값 변경
  - 200 이외 응답에서 data 필드 없는 예제 수정
  - 기타 등등

## 버그
- 밈 생성, 수정 시 `keywordIds` 를 string[] 으로 넣어주고있는 문제 수정 `ObjectId[]` 여야함 -> dev db는 수정해둠
- 인기 키워드 조회 API에서 키워드에 해당하는 밈 조회 쿼리 수정 (keywordIds과 완벽 일치하는지, string 비교로 발생한 문제)