### PR TITLE
deviceId 헤더 적용, API 엔드포인트 변경, 목록 조회 API 페이지네이션 적용

### DIFF
--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -186,7 +186,18 @@ const searchMemeListByKeyword = async (req: CustomRequest, res: Response, next: 
 
   try {
     const memeList = await MemeService.searchMemeByKeyword(page, size, keyword);
-    return res.json(createSuccessResponse(HttpCode.OK, 'Search meme list by keyword', memeList));
+    const data = {
+      pagination: {
+        total: memeList.total,
+        page: memeList.page,
+        perPage: size,
+        currentPage: memeList.page,
+        totalPages: memeList.totalPages,
+      },
+      memeList: memeList.data,
+    };
+
+    return res.json(createSuccessResponse(HttpCode.OK, 'Search meme list by keyword', data));
   } catch (err) {
     return next(new CustomError(err.message, err.status));
   }

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -171,12 +171,22 @@ const getTodayMemeList = async (req: Request, res: Response, next: NextFunction)
   }
 };
 
-const searchMemeByKeyword = async (req: CustomRequest, res: Response, next: NextFunction) => {
+const searchMemeListByKeyword = async (req: CustomRequest, res: Response, next: NextFunction) => {
   const keyword = req.requestedKeyword;
 
+  const page = parseInt(req.query.page as string) || 1;
+  if (page < 1) {
+    return next(new CustomError(`Invalid 'page' parameter`, HttpCode.BAD_REQUEST));
+  }
+
+  const size = parseInt(req.query.size as string) || 10;
+  if (size < 1) {
+    return next(new CustomError(`Invalid 'size' parameter`, HttpCode.BAD_REQUEST));
+  }
+
   try {
-    const memeList = await MemeService.searchMemeByKeyword(keyword);
-    return res.json(createSuccessResponse(HttpCode.OK, 'Search meme by keyword', memeList));
+    const memeList = await MemeService.searchMemeByKeyword(page, size, keyword);
+    return res.json(createSuccessResponse(HttpCode.OK, 'Search meme list by keyword', memeList));
   } catch (err) {
     return next(new CustomError(err.message, err.status));
   }
@@ -287,5 +297,5 @@ export {
   deleteMemeSave,
   updateMeme,
   getMemeWithKeywords,
-  searchMemeByKeyword,
+  searchMemeListByKeyword,
 };

--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -56,29 +56,50 @@ const getUser = async (req: CustomRequest, res: Response, next: NextFunction) =>
   }
 };
 
-const getLastSeenMeme = async (req: CustomRequest, res: Response, next: NextFunction) => {
+const getLastSeenMemes = async (req: CustomRequest, res: Response, next: NextFunction) => {
   const user = req.requestedUser;
 
   try {
-    const memeList = await UserService.getLastSeenMeme(user);
+    const memeList = await UserService.getLastSeenMemes(user);
     return res.json(createSuccessResponse(HttpCode.OK, 'Get Last Seen Meme', memeList));
   } catch (err) {
     return next(new CustomError(err.message, err.status));
   }
 };
 
-const getSavedMeme = async (req: CustomRequest, res: Response, next: NextFunction) => {
+const getSavedMemes = async (req: CustomRequest, res: Response, next: NextFunction) => {
   const user = req.requestedUser;
 
+  const page = parseInt(req.query.page as string) || 1;
+  if (page < 1) {
+    return next(new CustomError(`Invalid 'page' parameter`, HttpCode.BAD_REQUEST));
+  }
+
+  const size = parseInt(req.query.size as string) || 10;
+  if (size < 1) {
+    return next(new CustomError(`Invalid 'size' parameter`, HttpCode.BAD_REQUEST));
+  }
+
   try {
-    const memeList = await UserService.getSavedMeme(user);
-    return res.json(createSuccessResponse(HttpCode.OK, 'Get saved Meme List', memeList));
+    const memeList = await UserService.getSavedMemes(page, size, user);
+
+    const data = {
+      pagination: {
+        total: memeList.total,
+        page: memeList.page,
+        perPage: size,
+        currentPage: memeList.page,
+        totalPages: memeList.totalPages,
+      },
+      memeList: memeList.data,
+    };
+    return res.json(createSuccessResponse(HttpCode.OK, 'Get saved Meme List', data));
   } catch (err) {
     return next(new CustomError(err.message, err.status));
   }
 };
 
-export { getUser, createUser, getLastSeenMeme, getSavedMeme };
+export { getUser, createUser, getLastSeenMemes, getSavedMemes };
 
 function getLevel(watch: number, reaction: number, share: number): number {
   let level = 1;

--- a/src/middleware/requestedInfo.ts
+++ b/src/middleware/requestedInfo.ts
@@ -92,15 +92,15 @@ export const getRequestedUserInfo = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const deviceId = req.params?.deviceId || req.body?.deviceId || null;
+  const deviceId = req.headers['x-device-id'] as string;
 
-  if (_.isNull(deviceId)) {
-    return next(new CustomError(`'deviceId' should be provided`, HttpCode.BAD_REQUEST));
+  if (!deviceId) {
+    return next(new CustomError(`'x-device-id' header should be provided`, HttpCode.BAD_REQUEST));
   }
 
   const user = await getUser(deviceId);
 
-  if (_.isNull(user)) {
+  if (!user) {
     return next(new CustomError(`user(${deviceId}) does not exist`, HttpCode.NOT_FOUND));
   }
 

--- a/src/routes/keywordCategory.ts
+++ b/src/routes/keywordCategory.ts
@@ -16,8 +16,8 @@ const router = express.Router();
  * /api/keywordCategory:
  *   post:
  *     tags: [KeywordCategory]
- *     summary: 키워드 카테고리 생성
- *     description: 키워드 카테고리를 생성합니다
+ *     summary: 키워드 카테고리 생성 (백오피스)
+ *     description: 키워드 카테고리를 생성합니다 (백오피스)
  *     requestBody:
  *       required: true
  *       content:
@@ -25,7 +25,9 @@ const router = express.Router();
  *           schema:
  *             type: object
  *             properties:
- *               name: { type: string }
+ *               name:
+ *                type: string
+ *                example: 대학
  *     responses:
  *       '200':
  *         description: 키워드 카테고리 생성
@@ -48,10 +50,10 @@ const router = express.Router();
  *                   properties:
  *                     _id:
  *                       type: string
- *                       example: "5f5f5f5f5f5f5f5f5f5f5f5f"
+ *                       example: "66898279850f512db15ee832"
  *                     name:
  *                       type: string
- *                       example: "meme"
+ *                       example: "대학"
  *                     isRecommend:
  *                       type: boolean
  *                       example: true
@@ -107,14 +109,15 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  * /api/keywordCategory/{categoryName}:
  *   get:
  *     tags: [KeywordCategory]
- *     summary: 키워드 카테고리
- *     description: 키워드 카테고리를 반환합니다
+ *     summary: 키워드 카테고리 조회 (백오피스)
+ *     description: 키워드 카테고리를 조회한다.
  *     parameters:
  *       - in: path
  *         name: categoryName
  *         required: true
  *         schema:
  *           type: string
+ *           example: 대학생
  *         description: 키워드 카테고리
  *     responses:
  *       200:
@@ -138,10 +141,10 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                   properties:
  *                     _id:
  *                       type: string
- *                       example: "5f5f5f5f5f5f5f5f5f5f5f5f"
+ *                       example: "66898279850f512db15ee832"
  *                     name:
  *                       type: string
- *                       example: "meme"
+ *                       example: "대학생"
  *                     isRecommend:
  *                       type: boolean
  *                       example: false
@@ -191,8 +194,8 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                   example: Internal server error
  *   put:
  *     tags: [KeywordCategory]
- *     summary: 키워드 카테고리 수정
- *     description: 키워드 카테고리를 수정합니다
+ *     summary: 키워드 카테고리 수정 (백오피스)
+ *     description: 키워드 카테고리를 수정한다. (백오피스)
  *     parameters:
  *       - in: path
  *         name: categoryName
@@ -210,7 +213,7 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *               name: { type: string }
  *     responses:
  *       200:
- *         description: 키워드 카테고리를 수정해야다.
+ *         description: 키워드 카테고리 수정 성공
  *         content:
  *           application/json:
  *             schema:
@@ -230,7 +233,7 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                   properties:
  *                     _id:
  *                       type: string
- *                       example: "5f5f5f5f5f5f5f5f5f5f5f5f"
+ *                       example: "66898279850f512db15ee832"
  *                     name:
  *                       type: string
  *                       example: "meme"
@@ -286,8 +289,8 @@ router.post('/', validateCategoryDuplication, createKeywordCategory);
  *                   example: null
  *   delete:
  *     tags: [KeywordCategory]
- *     summary: 키워드 카테고리 삭제
- *     description: 키워드 카테고리를 삭제합니다
+ *     summary: 키워드 카테고리 삭제 (백오피스)
+ *     description: 키워드 카테고리를 삭제합니다 (백오피스)
  *     parameters:
  *       - in: path
  *         name: categoryName

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -162,7 +162,7 @@ router.get('/list', getAllMemeList); // meme 목록 전체 조회 (페이지네�
 
 /**
  * @swagger
- * /api/meme/todayMeme:
+ * /api/meme/recommend-meme:
  *   get:
  *     tags: [Meme]
  *     summary: 추천 밈 정보 조회
@@ -273,7 +273,7 @@ router.get('/list', getAllMemeList); // meme 목록 전체 조회 (페이지네�
  *                   type: null
  *                   example: null
  */
-router.get('/todayMeme', getTodayMemeList); // 오늘의 추천 밈 (5개)
+router.get('/recommend-meme', getTodayMemeList); // 오늘의 추천 밈 (5개)
 
 /**
  * @swagger

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -88,24 +88,29 @@ const router = express.Router();
  *                           _id:
  *                             type: string
  *                             example: "66805b1a72ef94c9c0ba134c"
- *                           title:
- *                             type: string
- *                             example: "title2"
  *                           image:
  *                             type: string
- *                             example: "image2"
- *                           reaction:
- *                             type: integer
- *                             example: 0
- *                           source:
- *                             type: string
- *                             example: "source2"
- *                           isTodayMeme:
- *                             type: boolean
- *                             example: false
+ *                             example: "https://example.com/meme.jpg"
  *                           isDeleted:
  *                             type: boolean
  *                             example: false
+ *                           isTodayMeme:
+ *                             type: boolean
+ *                             example: false
+ *                           keywordIds:
+ *                             type: array
+ *                             items:
+ *                               example: "667fee7ac58681a42d57dc3b"
+ *                           title:
+ *                             type: string
+ *                             example: "무한상사 정총무"
+ *                           source:
+ *                             type: string
+ *                             example: "무한도전 102화"
+ *                           reaction:
+ *                             type: integer
+ *                             example: 99
+ *                             description: 밈 리액션 수
  *                           createdAt:
  *                             type: string
  *                             format: date-time

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -27,7 +27,7 @@ const router = express.Router();
  *   get:
  *     tags:
  *       - Meme
- *     summary: 밈 전체 목록 조회
+ *     summary: 밈 전체 목록 조회 (페이지네이션 적용)
  *     description: 밈 전체 목록 조회
  *     parameters:
  *       - in: query
@@ -543,7 +543,7 @@ router.get('/:memeId', getMemeWithKeywords); // meme 조회
  * /api/meme/{memeId}:
  *   patch:
  *     tags: [Meme]
- *     summary: 밈 수정(백오피스)
+ *     summary: 밈 수정 (백오피스)
  *     description: 밈을 수정한다 (백오피스)
  *     parameters:
  *     - in: path
@@ -706,8 +706,8 @@ router.patch('/:memeId', getRequestedMemeInfo, updateMeme); // meme 수정
  * /api/meme/{memeId}:
  *   delete:
  *     tags: [Meme]
- *     summary: 밈 삭제(백오피스)
- *     description: 밈을 삭제한다.
+ *     summary: 밈 삭제 (백오피스)
+ *     description: 밈을 삭제한다. (백오피스용)
  *     parameters:
  *     - in: path
  *       name: memeId
@@ -799,20 +799,16 @@ router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
  *     summary: 밈 저장 (내 파밈함에 보관됨)
  *     description: 밈을 저장한다. 저장한 밈은 내 파밈함에 보관된다.
  *     parameters:
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *     - in: path
  *       name: memeId
  *       schema:
  *         type: string
  *       description: 저장할 밈 id
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               deviceId:
- *                 type: string
  *     responses:
  *       201:
  *         description: Meme successfully saved
@@ -891,7 +887,7 @@ router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
  *                   type: null
  *                   example: null
  */
-router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createMemeSave);
+router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createMemeSave); // meme 저장하기
 
 /**
  * @swagger
@@ -901,20 +897,16 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  *     summary: 밈 공유
  *     description: 밈 공유할 때 사용되는 api로 '밈 공유' 카운트를 올린다.
  *     parameters:
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *     - in: path
  *       name: memeId
  *       schema:
  *         type: string
  *       description: 공유할 밈 id
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               deviceId:
- *                 type: string
  *     responses:
  *       201:
  *         description: Meme successfully shared
@@ -993,7 +985,7 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  *                   type: null
  *                   example: null
  */
-router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, createMemeShare);
+router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, createMemeShare); // meme 공유하기
 
 /**
  * @swagger
@@ -1003,6 +995,11 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  *     summary: 밈 보기 (밈의 타입 필요)
  *     description: 사용자가 밈을 볼 때 사용되는 api로 '밈 보기' 카운트를 올린다. 밈의 타입을 적어줘야한다.
  *     parameters:
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *     - in: path
  *       name: memeId
  *       schema:
@@ -1014,16 +1011,6 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  *         type: string
  *       enum: [search, recommend]
  *       description: 밈 종류 (search - 검색으로 조회된 밈 / recommend - 추천 탭에서 조회된 밈)
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               deviceId:
- *                 type: string
- *                 description: The ID of the device/user
  *     responses:
  *       201:
  *         description: Meme watch interaction recorded successfully
@@ -1107,7 +1094,7 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  *                   type: null
  *                   example: null
  */
-router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, createMemeWatch);
+router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, createMemeWatch); // meme 보기
 
 /**
  * @swagger
@@ -1117,22 +1104,17 @@ router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, 
  *     summary: 밈 리액션(ㅋㅋㅋ)
  *     description: 밈 리액션 시 사용되는 api로 'ㅋ 남기기' 카운트를 올린다.
  *     parameters:
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *     - in: path
  *       name: memeId
  *       schema:
  *         type: string
  *       required: true
  *       description: 리액션할 밈 id
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               deviceId:
- *                 type: string
- *     responses:
  *       201:
  *         description: Created Meme Reaction
  *         content:
@@ -1207,7 +1189,7 @@ router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, 
  *                   type: null
  *                   example: null
  */
-router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, createMemeReaction);
+router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, createMemeReaction); // meme 리액션 남기기
 
 /**
  * @swagger

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -158,7 +158,7 @@ const router = express.Router();
  *                   type: null
  *                   example: null
  */
-router.get('/list', getAllMemeList); // meme 목록 전체 조회
+router.get('/list', getAllMemeList); // meme 목록 전체 조회 (페이지네이션)
 
 /**
  * @swagger
@@ -1352,6 +1352,6 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  *                   type: null
  *                   example: null
  */
-router.get('/search/:name', getKeywordInfoByName, searchMemeListByKeyword); // 키워드에 해당하는 밈 검색하기
+router.get('/search/:name', getKeywordInfoByName, searchMemeListByKeyword); // 키워드에 해당하는 밈 검색하기 (페이지네이션)
 
 export default router;

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -1308,6 +1308,14 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  *                             type: integer
  *                             example: 999
  *                             description: 밈 조회수
+ *                           createdAt:
+ *                             type: string
+ *                             format: date-time
+ *                             example: "2024-06-29T19:06:02.489Z"
+ *                           updatedAt:
+ *                             type: string
+ *                             format: date-time
+ *                             example: "2024-06-29T19:06:02.489Z"
  *       400:
  *         description: Invalid keyword name
  *         content:

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -162,7 +162,7 @@ router.get('/list', getAllMemeList); // meme 목록 전체 조회 (페이지네�
 
 /**
  * @swagger
- * /api/meme/recommend-meme:
+ * /api/meme/recommend-memes:
  *   get:
  *     tags: [Meme]
  *     summary: 추천 밈 정보 조회
@@ -273,7 +273,7 @@ router.get('/list', getAllMemeList); // meme 목록 전체 조회 (페이지네�
  *                   type: null
  *                   example: null
  */
-router.get('/recommend-meme', getTodayMemeList); // 오늘의 추천 밈 (5개)
+router.get('/recommend-memes', getTodayMemeList); // 오늘의 추천 밈 (5개)
 
 /**
  * @swagger

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -211,17 +211,29 @@ router.get('/', getRequestedUserInfo, UserController.getUser); // user 조회
  * /api/user/saved-memes:
  *   get:
  *     tags: [User]
- *     summary: 사용자가 저장한 밈 정보 조회 (나의 파밈함)
+ *     summary: 사용자가 저장한 밈 목록 조회 (나의 파밈함) - 페이지네이션
  *     description: 사용자가 저장한 밈 목록 (나의 파밈함)
  *     parameters:
- *     - name: x-device-id
- *       in: header
- *       description: 유저의 고유한 deviceId
- *       required: true
- *       type: string
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: number
+ *           example: 1
+ *           description: 현재 페이지 번호 (기본값 1)
+ *       - in: query
+ *         name: size
+ *         schema:
+ *           type: number
+ *           example: 10
+ *           description: 한 번에 조회할 밈 개수 (기본값 10)
+ *       - name: x-device-id
+ *         in: header
+ *         description: 유저의 고유한 deviceId
+ *         required: true
+ *         type: string
  *     responses:
  *       200:
- *         description: updated user
+ *         description: 사용자가 저장한 밈 목록 조회
  *         content:
  *           application/json:
  *             schema:
@@ -235,21 +247,67 @@ router.get('/', getRequestedUserInfo, UserController.getUser); // user 조회
  *                   example: 200
  *                 message:
  *                   type: string
- *                   example: Found User
+ *                   example: Get saved Meme List
  *                 data:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       _id:
- *                         type: string
- *                         example: "5f6f6b1d6ab9c8f7d9a4b5c6"
- *                       image:
- *                         type: string
- *                         example: "image5"
- *                       isTodayMeme:
- *                         type: boolean
- *                         example: true
+ *                   type: object
+ *                   properties:
+ *                     pagination:
+ *                       type: object
+ *                       properties:
+ *                         total:
+ *                           type: integer
+ *                           example: 2
+ *                         page:
+ *                           type: integer
+ *                           example: 1
+ *                         perPage:
+ *                           type: integer
+ *                           example: 10
+ *                         currentPage:
+ *                           type: integer
+ *                           example: 1
+ *                         totalPages:
+ *                           type: integer
+ *                           example: 1
+ *                     memeList:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           _id:
+ *                             type: string
+ *                             example: "66805b1a72ef94c9c0ba134c"
+ *                           image:
+ *                             type: string
+ *                             example: "https://example.com/meme.jpg"
+ *                           isDeleted:
+ *                             type: boolean
+ *                             example: false
+ *                           isTodayMeme:
+ *                             type: boolean
+ *                             example: false
+ *                           keywordIds:
+ *                             type: array
+ *                             items:
+ *                               example: "667fee7ac58681a42d57dc3b"
+ *                           title:
+ *                             type: string
+ *                             example: "무한상사 정총무"
+ *                           source:
+ *                             type: string
+ *                             example: "무한도전 102화"
+ *                           reaction:
+ *                             type: integer
+ *                             example: 99
+ *                             description: 밈 리액션 수
+ *                           createdAt:
+ *                             type: string
+ *                             format: date-time
+ *                             example: "2024-06-29T19:06:02.489Z"
+ *                           updatedAt:
+ *                             type: string
+ *                             format: date-time
+ *                             example: "2024-06-29T19:06:02.489Z"
  *       400:
  *         description: deviceId should be provided
  *         content:
@@ -290,7 +348,7 @@ router.get('/', getRequestedUserInfo, UserController.getUser); // user 조회
  *                   type: null
  *                   example: null
  */
-router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); // user가 저장한 meme 조회 (10개 제한)
+router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); // user가 저장한 meme 조회 (페이지네이션 적용)
 
 /**
  * @swagger
@@ -307,7 +365,7 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *       type: string
  *     responses:
  *       200:
- *         description: updated user
+ *         description: 최근에 본 밈 목록
  *         content:
  *           application/json:
  *             schema:
@@ -321,7 +379,7 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *                   example: 200
  *                 message:
  *                   type: string
- *                   example: get lastSeenMeme
+ *                   example: 최근에 본 밈 목록 조회
  *                 data:
  *                   type: array
  *                   items:
@@ -329,13 +387,38 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *                     properties:
  *                       _id:
  *                         type: string
- *                         example: "5f6f6b1d6ab9c8f7d9a4b5c6"
+ *                         example: "66805b1a72ef94c9c0ba134c"
  *                       image:
  *                         type: string
- *                         example: "http://image5"
+ *                         example: "https://example.com/meme.jpg"
+ *                       isDeleted:
+ *                         type: boolean
+ *                         example: false
  *                       isTodayMeme:
  *                         type: boolean
- *                         example: true
+ *                         example: false
+ *                       keywordIds:
+ *                         type: array
+ *                         items:
+ *                           example: "667fee7ac58681a42d57dc3b"
+ *                       title:
+ *                         type: string
+ *                         example: "무한상사 정총무"
+ *                       source:
+ *                         type: string
+ *                         example: "무한도전 102화"
+ *                       reaction:
+ *                         type: integer
+ *                         example: 99
+ *                         description: 밈 리액션 수
+ *                       createdAt:
+ *                         type: string
+ *                         format: date-time
+ *                         example: "2024-06-29T19:06:02.489Z"
+ *                       updatedAt:
+ *                         type: string
+ *                         format: date-time
+ *                         example: "2024-06-29T19:06:02.489Z"
  *       400:
  *         description: deviceId should be provided
  *         content:
@@ -376,6 +459,6 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *                   type: null
  *                   example: null
  */
-router.get('/recent-memes', getRequestedUserInfo, UserController.getLastSeenMeme); // user가 최근에 본 밈 정보 조회
+router.get('/recent-memes', getRequestedUserInfo, UserController.getLastSeenMeme); // user가 최근에 본 밈 정보 조회 (10개 제한)
 
 export default router;

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -348,7 +348,7 @@ router.get('/', getRequestedUserInfo, UserController.getUser); // user 조회
  *                   type: null
  *                   example: null
  */
-router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); // user가 저장한 meme 조회 (페이지네이션 적용)
+router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMemes); // user가 저장한 meme 조회 (페이지네이션 적용)
 
 /**
  * @swagger
@@ -379,7 +379,7 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *                   example: 200
  *                 message:
  *                   type: string
- *                   example: 최근에 본 밈 목록 조회
+ *                   example: Get Last Seen Meme
  *                 data:
  *                   type: array
  *                   items:
@@ -459,6 +459,6 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *                   type: null
  *                   example: null
  */
-router.get('/recent-memes', getRequestedUserInfo, UserController.getLastSeenMeme); // user가 최근에 본 밈 정보 조회 (10개 제한)
+router.get('/recent-memes', getRequestedUserInfo, UserController.getLastSeenMemes); // user가 최근에 본 밈 정보 조회 (10개 제한)
 
 export default router;

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -122,8 +122,8 @@ router.post('/', UserController.createUser); // user 생성
  * /api/user:
  *   get:
  *     tags: [User]
- *     summary: user
- *     description: user
+ *     summary: 유저 정보 조회
+ *     description: 유저 정보 조회
  *     parameters:
  *     - name: x-device-id
  *       in: header

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -10,8 +10,8 @@ const router = express.Router();
  *  /api/user:
  *    post:
  *      tags: [User]
- *      summary: user 생성
- *      description: user 생성
+ *      summary: 유저 생성
+ *      description: 유저를 생성한다.
  *      requestBody:
  *        required: true
  *        content:
@@ -19,9 +19,12 @@ const router = express.Router();
  *            schema:
  *              type: object
  *              properties:
- *                deviceId: { type: string }
+ *                deviceId:
+ *                  type: string
+ *                  example: abcdefgh
+ *                  description: 유저의 디바이스 아이디
  *      responses:
- *        200:
+ *        '200':
  *          description: user
  *          content:
  *            application/json:
@@ -43,11 +46,14 @@ const router = express.Router();
  *                      deviceId:
  *                        type: string
  *                        example: "deviceId"
+ *                        description: 유저의 deviceId
  *                      lastSeenMeme:
  *                        type: array
+ *                        description: 최근에 본 밈 id (최대 10개)
  *                        items:
  *                          type: string
  *                          example: "66805b1a72ef94c9c0ba134c"
+ *                        default: []
  *                      isDeleted:
  *                        type: boolean
  *                        example: false
@@ -70,7 +76,7 @@ const router = express.Router();
  *                        type: integer
  *                        example: 1
  *        400:
- *          description: deviceId' field should be provided
+ *          description: deviceId field should be provided
  *          content:
  *            application/json:
  *              schema:
@@ -84,10 +90,10 @@ const router = express.Router();
  *                    example: 400
  *                  message:
  *                    type: string
- *                    example: deviceId' field should be provided
- *                 data:
- *                   type: null
- *                   example: null
+ *                    example: deviceId field should be provided
+ *                  data:
+ *                    type: null
+ *                    example: null
  *        500:
  *          description: Internal server error
  *          content:
@@ -105,25 +111,25 @@ const router = express.Router();
  *                    type: string
  *                    example:
  *                      Internal server error
- *                 data:
- *                   type: null
- *                   example: null
+ *                  data:
+ *                    type: null
+ *                    example: null
  */
 router.post('/', UserController.createUser); // user 생성
 
 /**
  * @swagger
- * /api/user/{deviceId}:
+ * /api/user:
  *   get:
  *     tags: [User]
  *     summary: user
  *     description: user
  *     parameters:
- *     - in: path
- *       name: deviceId
- *       schema:
- *         type: string
- *       description: deviceId
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *     responses:
  *       200:
  *         description: get user
@@ -152,9 +158,11 @@ router.post('/', UserController.createUser); // user 생성
  *                       example: "deviceId"
  *                     lastSeenMeme:
  *                       type: array
+ *                       description: 최근에 본 밈 id (최대 10개)
  *                       items:
  *                         type: string
  *                         example: "66805b1a72ef94c9c0ba134c"
+ *                       default: []
  *                     isDeleted:
  *                       type: boolean
  *                       example: false
@@ -177,7 +185,7 @@ router.post('/', UserController.createUser); // user 생성
  *                       type: integer
  *                       example: 1
  *       400:
- *         description: deviceID should be provided
+ *         description: deviceId should be provided
  *         content:
  *           application/json:
  *             schema:
@@ -191,12 +199,12 @@ router.post('/', UserController.createUser); // user 생성
  *                   example: 400
  *                 message:
  *                   type: string
- *                   example: deviceID should be provided
+ *                   example: deviceId should be provided
  *                 data:
  *                   type: null
  *                   example: null
  */
-router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 조회
+router.get('/', getRequestedUserInfo, UserController.getUser); // user 조회
 
 /**
  * @swagger
@@ -204,13 +212,13 @@ router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 
  *   get:
  *     tags: [User]
  *     summary: 사용자가 저장한 밈 정보 조회 (나의 파밈함)
- *     description: user
+ *     description: 사용자가 저장한 밈 목록 (나의 파밈함)
  *     parameters:
- *     - in: path
- *       name: deviceId
- *       schema:
- *         type: string
- *       description: deviceId
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *     responses:
  *       200:
  *         description: updated user
@@ -243,7 +251,7 @@ router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 
  *                         type: boolean
  *                         example: true
  *       400:
- *         description: deviceID should be provided
+ *         description: deviceId should be provided
  *         content:
  *           application/json:
  *             schema:
@@ -257,7 +265,7 @@ router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 
  *                   example: 400
  *                 message:
  *                   type: string
- *                   example: deviceID should be provided
+ *                   example: deviceId should be provided
  *                 data:
  *                   type: null
  *                   example: null
@@ -290,13 +298,13 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *   get:
  *     tags: [User]
  *     summary: 사용자가 최근에 본 밈 정보 조회 (최근 본 밈)
- *     description: user
+ *     description: 사용자가 최근에 본 밈 정보 조회 (최근 본 밈)
  *     parameters:
- *     - in: path
- *       name: deviceId
- *       schema:
- *         type: string
- *       description: deviceId
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *     responses:
  *       200:
  *         description: updated user
@@ -329,7 +337,7 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *                         type: boolean
  *                         example: true
  *       400:
- *         description: deviceID should be provided
+ *         description: deviceId should be provided
  *         content:
  *           application/json:
  *             schema:
@@ -343,7 +351,7 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); /
  *                   example: 400
  *                 message:
  *                   type: string
- *                   example: deviceID should be provided
+ *                   example: deviceId should be provided
  *                 data:
  *                   type: null
  *                   example: null

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -200,10 +200,10 @@ router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 
 
 /**
  * @swagger
- * /api/user/{deviceId}/save:
+ * /api/user/saved-memes:
  *   get:
  *     tags: [User]
- *     summary: user
+ *     summary: 사용자가 저장한 밈 정보 조회 (나의 파밈함)
  *     description: user
  *     parameters:
  *     - in: path
@@ -282,14 +282,14 @@ router.get('/:deviceId', getRequestedUserInfo, UserController.getUser); // user 
  *                   type: null
  *                   example: null
  */
-router.get('/:deviceId/save', getRequestedUserInfo, UserController.getSavedMeme); // user가 저장한 meme 조회
+router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMeme); // user가 저장한 meme 조회 (10개 제한)
 
 /**
  * @swagger
- * /api/user/{deviceId}/lastSeenMeme:
+ * /api/user/recent-memes:
  *   get:
  *     tags: [User]
- *     summary: user
+ *     summary: 사용자가 최근에 본 밈 정보 조회 (최근 본 밈)
  *     description: user
  *     parameters:
  *     - in: path
@@ -368,6 +368,6 @@ router.get('/:deviceId/save', getRequestedUserInfo, UserController.getSavedMeme)
  *                   type: null
  *                   example: null
  */
-router.get('/:deviceId/lastSeenMeme', getRequestedUserInfo, UserController.getLastSeenMeme);
+router.get('/recent-memes', getRequestedUserInfo, UserController.getLastSeenMeme); // user가 최근에 본 밈 정보 조회
 
 export default router;

--- a/src/service/meme.service.ts
+++ b/src/service/meme.service.ts
@@ -165,10 +165,7 @@ async function searchMemeByKeyword(
       isDeleted: false,
     });
 
-    const memeList = await MemeModel.find(
-      { keywordIds: { $in: keyword._id } },
-      { createdAt: 0, updatedAt: 0 },
-    )
+    const memeList = await MemeModel.find({ keywordIds: { $in: keyword._id } })
       .skip((page - 1) * size)
       .limit(size)
       .sort({ reaction: -1 })

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -1,17 +1,17 @@
+import { startOfWeek } from 'date-fns';
 import _ from 'lodash';
 
 import CustomError from '../errors/CustomError';
 import { HttpCode } from '../errors/HttpCode';
 import { IMemeDocument, MemeModel } from '../model/meme';
 import { InteractionType, MemeInteractionModel } from '../model/memeInteraction';
-import { IUser, IUserDocument, IUserInfos, UserModel } from '../model/user';
 import {
   MemeRecommendWatchModel,
   IMemeRecommendWatchUpdatePayload,
   IMemeRecommendWatchCreatePayload,
 } from '../model/memeRecommendWatch';
+import { IUser, IUserDocument, IUserInfos, UserModel } from '../model/user';
 import { logger } from '../util/logger';
-import { startOfWeek } from 'date-fns';
 
 async function getUser(deviceId: string): Promise<IUserDocument | null> {
   try {

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -126,13 +126,10 @@ async function updateLastSeenMeme(user: IUserDocument, meme: IMemeDocument): Pro
 async function getLastSeenMeme(user: IUserDocument): Promise<IMemeDocument[]> {
   try {
     const lastSeenMeme = user.lastSeenMeme;
-    const memeList = await MemeModel.find(
-      {
-        _id: { $in: lastSeenMeme },
-        isDeleted: false,
-      },
-      { createdAt: 0, updatedAt: 0, isDeleted: 0 },
-    ).lean();
+    const memeList = await MemeModel.find({
+      _id: { $in: lastSeenMeme },
+      isDeleted: false,
+    }).lean();
 
     return memeList;
   } catch (err) {
@@ -152,13 +149,10 @@ async function getSavedMeme(user: IUserDocument): Promise<IMemeDocument[]> {
       isDeleted: false,
     }).lean();
 
-    const memeList = await MemeModel.find(
-      {
-        _id: { $in: savedMeme.map((meme) => meme.memeId) },
-        isDeleted: false,
-      },
-      { createdAt: 0, updatedAt: 0, isDeleted: 0 },
-    ).lean();
+    const memeList = await MemeModel.find({
+      _id: { $in: savedMeme.map((meme) => meme.memeId) },
+      isDeleted: false,
+    }).lean();
 
     logger.info(
       `Get savedMeme - deviceId(${user.deviceId}), memeList(${JSON.stringify(memeList)})`,

--- a/test/meme/get-recommend-meme-list.test.ts
+++ b/test/meme/get-recommend-meme-list.test.ts
@@ -10,7 +10,7 @@ const totalCount = 10;
 let keywordIds = [];
 let keywords = [];
 
-describe("[GET] '/api/meme/todayMeme' ", () => {
+describe("[GET] '/api/meme/recommend-meme' ", () => {
   beforeEach(async () => {
     const keywordMockDatas = createKeywordMockData(5);
     const createdKeywords = await KeywordModel.insertMany(keywordMockDatas);
@@ -23,32 +23,36 @@ describe("[GET] '/api/meme/todayMeme' ", () => {
     await KeywordModel.deleteMany({});
   });
 
-  it('should return list of todayMeme - default size: 5', async () => {
+  it('should return list of recommend-meme - default size: 5', async () => {
     const mockDatas = createMockData(totalCount, 5, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
-    const response = await request(app).get('/api/meme/todayMeme');
+    const response = await request(app).get('/api/meme/recommend-meme');
     expect(response.statusCode).toBe(200);
     expect(response.body.data.length).toBe(5);
   });
 
-  it('should return list of todayMeme - customize size', async () => {
+  it('should return list of recommend-meme - customize size', async () => {
     const customizedTodayMemeCount = 3;
     const mockDatas = createMockData(totalCount, customizedTodayMemeCount, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
-    const response = await request(app).get(`/api/meme/todayMeme?size=${customizedTodayMemeCount}`);
+    const response = await request(app).get(
+      `/api/meme/recommend-meme?size=${customizedTodayMemeCount}`,
+    );
 
     expect(response.statusCode).toBe(200);
     expect(response.body.data.length).toBe(customizedTodayMemeCount);
   });
 
-  it('should not return list of todayMeme - customize size: bigger than limit(5)', async () => {
+  it('should not return list of recommend-meme - customize size: bigger than limit(5)', async () => {
     const customizedTodayMemeCount = 10;
     const mockDatas = createMockData(totalCount, customizedTodayMemeCount, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
-    const response = await request(app).get(`/api/meme/todayMeme?size=${customizedTodayMemeCount}`);
+    const response = await request(app).get(
+      `/api/meme/recommend-meme?size=${customizedTodayMemeCount}`,
+    );
 
     expect(response.statusCode).toBe(400);
   });

--- a/test/meme/get-recommend-meme-list.test.ts
+++ b/test/meme/get-recommend-meme-list.test.ts
@@ -10,7 +10,7 @@ const totalCount = 10;
 let keywordIds = [];
 let keywords = [];
 
-describe("[GET] '/api/meme/recommend-meme' ", () => {
+describe("[GET] '/api/meme/recommend-memes' ", () => {
   beforeEach(async () => {
     const keywordMockDatas = createKeywordMockData(5);
     const createdKeywords = await KeywordModel.insertMany(keywordMockDatas);
@@ -23,35 +23,35 @@ describe("[GET] '/api/meme/recommend-meme' ", () => {
     await KeywordModel.deleteMany({});
   });
 
-  it('should return list of recommend-meme - default size: 5', async () => {
+  it('should return list of recommend-memes - default size: 5', async () => {
     const mockDatas = createMockData(totalCount, 5, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
-    const response = await request(app).get('/api/meme/recommend-meme');
+    const response = await request(app).get('/api/meme/recommend-memes');
     expect(response.statusCode).toBe(200);
     expect(response.body.data.length).toBe(5);
   });
 
-  it('should return list of recommend-meme - customize size', async () => {
+  it('should return list of recommend-memes - customize size', async () => {
     const customizedTodayMemeCount = 3;
     const mockDatas = createMockData(totalCount, customizedTodayMemeCount, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
     const response = await request(app).get(
-      `/api/meme/recommend-meme?size=${customizedTodayMemeCount}`,
+      `/api/meme/recommend-memes?size=${customizedTodayMemeCount}`,
     );
 
     expect(response.statusCode).toBe(200);
     expect(response.body.data.length).toBe(customizedTodayMemeCount);
   });
 
-  it('should not return list of recommend-meme - customize size: bigger than limit(5)', async () => {
+  it('should not return list of recommend-memes - customize size: bigger than limit(5)', async () => {
     const customizedTodayMemeCount = 10;
     const mockDatas = createMockData(totalCount, customizedTodayMemeCount, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
     const response = await request(app).get(
-      `/api/meme/recommend-meme?size=${customizedTodayMemeCount}`,
+      `/api/meme/recommend-memes?size=${customizedTodayMemeCount}`,
     );
 
     expect(response.statusCode).toBe(400);


### PR DESCRIPTION
## 정책 변경
- deviceId를 body parameter가 아닌 header로 요청하도록 변경
- meme api endpoint 변경
  - **kebab case**로 변경 `GET /api/meme/recommend-memes`
- user api endpoint 변경
  - deviceId parameter 제거
  - **kebab case**로 변경 `GET /api/user/saved-memes`, `GET /api/user/recent-memes`
- 목록 조회 페이지네이션 적용
  - 나의 파밈 함 조회 (`GET /api/user/saved-memes`)
  - 키워드로 밈 검색 (`GET /api/meme/search/:name`)

## 개선
- 스웨거 수정
  - 백오피스용 api는 전부 백오피스라고 설명 추가
  - 이상한 필드, 예시 들어간거 수정
  - 정책 변경에 해당하는 부분들 추가

## 버그
- 밈 keywordIds에 키워드의 _id를 포함하고있는지 찾는 쿼리에서 `$in` 연산자 누락
- 저장된 밈 목록을 찾는 쿼리에서 `$in` 연산자 누락