### PR TITLE
API별 헤더 추가, MemeInteractionService 추가

### DIFF
--- a/get-s3.js
+++ b/get-s3.js
@@ -1,0 +1,1 @@
+const AWS = require('aws-sdk')

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -167,6 +167,7 @@ const getTodayMemeList = async (req: CustomRequest, res: Response, next: NextFun
 };
 
 const searchMemeListByKeyword = async (req: CustomRequest, res: Response, next: NextFunction) => {
+  const user = req.requestedUser;
   const keyword = req.requestedKeyword;
 
   const page = parseInt(req.query.page as string) || 1;

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -51,7 +51,7 @@ const getMemeWithKeywords = async (req: CustomRequest, res: Response, next: Next
     }
 
     logger.info(`Get meme with keywords - ${meme._id})`);
-    return res.json(createSuccessResponse(HttpCode.OK, 'Get Meme', meme));
+    return res.json(createSuccessResponse(HttpCode.OK, 'Get Meme', ret));
   } catch (err) {
     return next(new CustomError(err.message, err.status));
   }

--- a/src/controller/meme.controller.ts
+++ b/src/controller/meme.controller.ts
@@ -181,7 +181,7 @@ const searchMemeListByKeyword = async (req: CustomRequest, res: Response, next: 
   }
 
   try {
-    const memeList = await MemeService.searchMemeByKeyword(page, size, keyword);
+    const memeList = await MemeService.searchMemeByKeyword(page, size, keyword, user);
     const data = {
       pagination: {
         total: memeList.total,

--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -33,18 +33,18 @@ const getUser = async (req: CustomRequest, res: Response, next: NextFunction) =>
   }
 };
 
-const getLastSeenMemes = async (req: CustomRequest, res: Response, next: NextFunction) => {
+const getLastSeenMemeList = async (req: CustomRequest, res: Response, next: NextFunction) => {
   const user = req.requestedUser;
 
   try {
-    const memeList = await UserService.getLastSeenMemes(user);
+    const memeList = await UserService.getLastSeenMemeList(user);
     return res.json(createSuccessResponse(HttpCode.OK, 'Get Last Seen Meme', memeList));
   } catch (err) {
     return next(new CustomError(err.message, err.status));
   }
 };
 
-const getSavedMemes = async (req: CustomRequest, res: Response, next: NextFunction) => {
+const getSavedMemeList = async (req: CustomRequest, res: Response, next: NextFunction) => {
   const user = req.requestedUser;
 
   const page = parseInt(req.query.page as string) || 1;
@@ -58,7 +58,7 @@ const getSavedMemes = async (req: CustomRequest, res: Response, next: NextFuncti
   }
 
   try {
-    const memeList = await UserService.getSavedMemes(page, size, user);
+    const memeList = await UserService.getSavedMemeList(page, size, user);
 
     const data = {
       pagination: {
@@ -76,7 +76,7 @@ const getSavedMemes = async (req: CustomRequest, res: Response, next: NextFuncti
   }
 };
 
-export { getUser, createUser, getLastSeenMemes, getSavedMemes };
+export { getUser, createUser, getLastSeenMemeList, getSavedMemeList };
 
 function getLevel(watch: number, reaction: number, share: number): number {
   let level = 1;

--- a/src/middleware/requestedInfo.ts
+++ b/src/middleware/requestedInfo.ts
@@ -56,8 +56,7 @@ export const getKeywordInfoByName = async (
   }
 
   const keyword = await getKeywordByName(keywordName);
-
-  if (!keyword) {
+  if (_.isNull(keyword)) {
     return next(
       new CustomError(`Keyword with name ${keywordName} does not exist`, HttpCode.NOT_FOUND),
     );
@@ -100,7 +99,7 @@ export const getRequestedUserInfo = async (
 
   const user = await getUser(deviceId);
 
-  if (!user) {
+  if (_.isNull(user)) {
     return next(new CustomError(`user(${deviceId}) does not exist`, HttpCode.NOT_FOUND));
   }
 

--- a/src/model/meme.ts
+++ b/src/model/meme.ts
@@ -1,4 +1,5 @@
 import mongoose, { Schema, Document, Types } from 'mongoose';
+
 import { IKeywordGetResponse } from './keyword';
 
 export interface IMemeCreatePayload {
@@ -24,18 +25,9 @@ export interface IMeme {
   isTodayMeme: boolean;
 }
 
-export interface IMemeGetResponse {
-  _id: Types.ObjectId;
-  title: string;
+export interface IMemeGetResponse extends Omit<IMemeDocument, 'keywordIds'> {
   keywords: IKeywordGetResponse[];
-  image: string;
-  reaction: number;
-  source: string;
-  isTodayMeme: boolean;
   isSaved: boolean; // 나의 파밈함 저장 여부
-  createdAt: Date;
-  updatedAt: Date;
-  isDeleted: boolean;
 }
 
 export interface IMemeDocument extends Document {

--- a/src/model/memeInteraction.ts
+++ b/src/model/memeInteraction.ts
@@ -8,14 +8,14 @@ export enum InteractionType {
 }
 
 export interface IMemeInteraction {
-  deviceId: String;
+  deviceId: string;
   memeId: Types.ObjectId;
   interactionType: InteractionType;
 }
 
-export interface IMemeInteraction extends Document {
+export interface IMemeInteractionDocument extends Document {
   _id: Types.ObjectId;
-  deviceId: String;
+  deviceId: string;
   memeId: Types.ObjectId;
   interactionType: InteractionType;
   isDeleted: boolean;
@@ -37,7 +37,7 @@ const MemeInteractionSchema: Schema = new Schema(
   },
 );
 
-export const MemeInteractionModel = mongoose.model<IMemeInteraction>(
+export const MemeInteractionModel = mongoose.model<IMemeInteractionDocument>(
   'memeInteraction',
   MemeInteractionSchema,
 );

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -31,6 +31,11 @@ const router = express.Router();
  *     summary: 밈 전체 목록 조회 (페이지네이션 적용)
  *     description: 밈 전체 목록 조회
  *     parameters:
+ *       - name: x-device-id
+ *         in: header
+ *         description: 유저의 고유한 deviceId
+ *         required: true
+ *         type: string
  *       - in: query
  *         name: page
  *         schema:
@@ -176,6 +181,11 @@ router.get('/list', getRequestedUserInfo, getAllMemeList); // meme 목록 전체
  *     summary: 추천 밈 정보 조회
  *     description: 추천 밈 목록을 조회한다. (현재는 주 단위, 추후 일 단위로 변경될 수 있음)
  *     parameters:
+ *       - name: x-device-id
+ *         in: header
+ *         description: 유저의 고유한 deviceId
+ *         required: true
+ *         type: string
  *       - in: query
  *         name: size
  *         schema:
@@ -426,6 +436,11 @@ router.post('/', createMeme); // meme 생성
  *     summary: 밈 정보 조회(키워드 포함)
  *     description: 밈 정보를 조회한다. 밈의 키워드 정보도 함께 포함한다. 이때 키워드는 키워드명만 제공된다 (키워드의 개별 정보 X)
  *     parameters:
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *     - in: path
  *       name: memeId
  *       required: true
@@ -1319,6 +1334,11 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  *     summary: 키워드가 포함된 밈 검색 (페이지네이션 적용)
  *     description: 키워드 클릭 시 해당 키워드를 포함한 밈을 조회하고 목록을 반환한다.
  *     parameters:
+ *     - name: x-device-id
+ *       in: header
+ *       description: 유저의 고유한 deviceId
+ *       required: true
+ *       type: string
  *       - in: query
  *         name: page
  *         schema:
@@ -1462,6 +1482,6 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  *                   type: null
  *                   example: null
  */
-router.get('/search/:name', getKeywordInfoByName, searchMemeListByKeyword); // 키워드에 해당하는 밈 검색하기 (페이지네이션)
+router.get('/search/:name', getRequestedUserInfo, getKeywordInfoByName, searchMemeListByKeyword); // 키워드에 해당하는 밈 검색하기 (페이지네이션)
 
 export default router;

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -446,7 +446,7 @@ router.post('/', createMeme); // meme 생성
  *       required: true
  *       schema:
  *         type: string
- *       description: 밈 ID
+ *         description: 밈 ID
  *     responses:
  *       200:
  *         description: The meme
@@ -841,7 +841,7 @@ router.delete('/:memeId', getRequestedMemeInfo, deleteMeme); // meme 삭제
  *       name: memeId
  *       schema:
  *         type: string
- *       description: 저장할 밈 id
+ *         description: 저장할 밈 id
  *     responses:
  *       201:
  *         description: Meme successfully saved
@@ -939,7 +939,7 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  *       name: memeId
  *       schema:
  *         type: string
- *       description: 저장할 밈 id
+ *         description: 저장할 밈 id
  *     responses:
  *       200:
  *         description: Meme successfully saved
@@ -1038,7 +1038,7 @@ router.delete('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, delet
  *       name: memeId
  *       schema:
  *         type: string
- *       description: 공유할 밈 id
+ *         description: 공유할 밈 id
  *     responses:
  *       201:
  *         description: Meme successfully shared
@@ -1137,7 +1137,7 @@ router.post('/:memeId/share', getRequestedUserInfo, getRequestedMemeInfo, create
  *       required: true
  *       schema:
  *         type: string
- *       description: 밈 id
+ *         description: 밈 id
  *     - in: path
  *       name: type
  *       required: true
@@ -1247,8 +1247,8 @@ router.post('/:memeId/watch/:type', getRequestedUserInfo, getRequestedMemeInfo, 
  *       name: memeId
  *       schema:
  *         type: string
- *       required: true
- *       description: 리액션할 밈 id
+ *         required: true
+ *         description: 리액션할 밈 id
  *     responses:
  *       201:
  *         description: Created Meme Reaction
@@ -1339,25 +1339,25 @@ router.post('/:memeId/reaction', getRequestedUserInfo, getRequestedMemeInfo, cre
  *       description: 유저의 고유한 deviceId
  *       required: true
  *       type: string
- *       - in: query
- *         name: page
- *         schema:
- *           type: number
- *           example: 1
- *           description: 현재 페이지 번호 (기본값 1)
- *       - in: query
- *         name: size
- *         schema:
- *           type: number
- *           example: 10
- *           description: 한 번에 조회할 밈 개수 (기본값 10)
- *       - in: path
- *         name: name
- *         schema:
- *           type: string
- *           example: "행복"
- *           required: true
- *           description: 키워드명
+ *     - in: query
+ *       name: page
+ *       schema:
+ *         type: number
+ *         example: 1
+ *         description: 현재 페이지 번호 (기본값 1)
+ *     - in: query
+ *       name: size
+ *       schema:
+ *         type: number
+ *         example: 10
+ *         description: 한 번에 조회할 밈 개수 (기본값 10)
+ *     - in: path
+ *       name: name
+ *       schema:
+ *         type: string
+ *         example: "행복"
+ *         required: true
+ *         description: 키워드명
  *     responses:
  *       200:
  *         description: 키워드를 포함한 밈 목록

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -362,7 +362,7 @@ router.get('/', getRequestedUserInfo, UserController.getUser); // user 조회
  *                   type: null
  *                   example: null
  */
-router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMemes); // user가 저장한 meme 조회 (페이지네이션 적용)
+router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMemeList); // user가 저장한 meme 조회 (페이지네이션 적용)
 
 /**
  * @swagger
@@ -484,6 +484,6 @@ router.get('/saved-memes', getRequestedUserInfo, UserController.getSavedMemes); 
  *                   type: null
  *                   example: null
  */
-router.get('/recent-memes', getRequestedUserInfo, UserController.getLastSeenMemes); // user가 최근에 본 밈 정보 조회 (10개 제한)
+router.get('/recent-memes', getRequestedUserInfo, UserController.getLastSeenMemeList); // user가 최근에 본 밈 정보 조회 (10개 제한)
 
 export default router;

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -288,7 +288,7 @@ router.get('/', getRequestedUserInfo, UserController.getUser); // user 조회
  *                             example: false
  *                           isSaved:
  *                             type: boolean
- *                             example: false
+ *                             example: true
  *                           keywords:
  *                             type: array
  *                             items:

--- a/src/service/keyword.service.ts
+++ b/src/service/keyword.service.ts
@@ -49,7 +49,7 @@ async function updateKeyword(
 }
 async function deleteKeyword(keywordId: Types.ObjectId): Promise<boolean> {
   const deletedKeyword = await KeywordModel.findOneAndDelete({ _id: keywordId }).lean();
-  if (!deletedKeyword) {
+  if (_.isNull(deletedKeyword)) {
     throw new CustomError(`Keyword with ID ${keywordId} not found`, HttpCode.NOT_FOUND);
   }
   return true;
@@ -75,7 +75,7 @@ async function increaseSearchCount(keywordId: Types.ObjectId): Promise<IKeywordD
       { $inc: { searchCount: 1 } },
       { new: true, projection: { isDeleted: 0 } },
     );
-    if (!updatedKeyword) {
+    if (_.isNull(updatedKeyword)) {
       throw new CustomError(`KeywordId ${keywordId} not found`, HttpCode.NOT_FOUND);
     }
     return updatedKeyword;

--- a/src/service/keyword.service.ts
+++ b/src/service/keyword.service.ts
@@ -85,21 +85,29 @@ async function increaseSearchCount(keywordId: Types.ObjectId): Promise<IKeywordD
   }
 }
 
-async function getKeywordByName(keywordName: string): Promise<IKeywordDocument> {
+async function getKeywordByName(keywordName: string): Promise<IKeywordDocument | null> {
   try {
     const keyword = await KeywordModel.findOne({ name: keywordName, isDeleted: false }).lean();
-    return keyword;
+    return keyword || null;
   } catch (err) {
-    logger.info(`Failed to get a Keyword Info By Name(${keywordName})`);
+    logger.error(`Failed to get a Keyword Info By Name(${keywordName})`);
+    throw new CustomError(
+      `Failed to get a Keyword Info By Name(${keywordName}) (${err.message})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
   }
 }
 
-async function getKeywordById(keywordId: Types.ObjectId): Promise<IKeywordDocument> {
+async function getKeywordById(keywordId: Types.ObjectId): Promise<IKeywordDocument | null> {
   try {
     const keyword = await KeywordModel.findOne({ _id: keywordId, isDeleted: false }).lean();
-    return keyword;
+    return keyword || null;
   } catch (err) {
     logger.info(`Failed to get a Keyword Info By id (${keywordId})`);
+    throw new CustomError(
+      `Failed to get a Keyword Info By id(${keywordId}) (${err.message})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
   }
 }
 
@@ -116,7 +124,11 @@ async function getKeywordInfoByKeywordIds(
     ).lean();
     return keyword;
   } catch (err) {
-    logger.info(`Failed to get a Keyword Info By id (${keywordIds})`);
+    logger.error(`Failed to get a Keyword Info By keywordIds(${JSON.stringify(keywordIds)})`);
+    throw new CustomError(
+      `Failed to get a Keyword Info By keywordIds(${JSON.stringify(keywordIds)})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
   }
 }
 

--- a/src/service/keywordCategory.service.ts
+++ b/src/service/keywordCategory.service.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import CustomError from '../errors/CustomError';
 import { HttpCode } from '../errors/HttpCode';
 import {
@@ -35,11 +37,11 @@ async function updateKeywordCategory(
     { new: true },
   );
 
-  if (!updatedCategory) {
+  if (_.isNull(updatedCategory)) {
     throw new CustomError(`Category with ID ${updatedCategory} not found`, HttpCode.NOT_FOUND);
   }
-  logger.info(`Update keyword category - category(${categoryName})`);
 
+  logger.info(`Update keyword category - category(${categoryName})`);
   return updatedCategory.toObject();
 }
 
@@ -50,19 +52,19 @@ async function deleteKeywordCategory(categoryName: string): Promise<boolean> {
     },
     { isDeleted: true },
   );
-  if (!deletedCategory) {
+  if (_.isNull(deletedCategory)) {
     throw new CustomError(`Category with Name ${categoryName} not found`, HttpCode.NOT_FOUND);
   }
   return true;
 }
 
-async function getKeywordCategory(categoryName: string): Promise<IKeywordCategoryDocument | null> {
+async function getKeywordCategory(categoryName: string): Promise<IKeywordCategoryDocument> {
   const keywordCategory = await KeywordCategoryModel.findOne({
     name: categoryName,
     isDeleted: false,
   });
 
-  if (!keywordCategory) {
+  if (_.isNull(keywordCategory)) {
     throw new CustomError(`Category with Name ${categoryName} not found`, HttpCode.NOT_FOUND);
   }
 

--- a/src/service/memeInteraction.service.ts
+++ b/src/service/memeInteraction.service.ts
@@ -1,0 +1,211 @@
+import CustomError from '../errors/CustomError';
+import { HttpCode } from '../errors/HttpCode';
+import { IMemeDocument, MemeModel } from '../model/meme';
+import {
+  IMemeInteractionDocument,
+  InteractionType,
+  MemeInteractionModel,
+} from '../model/memeInteraction';
+import { IUserDocument } from '../model/user';
+import { logger } from '../util/logger';
+
+async function getMemeInteractionInfo(
+  user: IUserDocument,
+  meme: IMemeDocument,
+  interactionType: InteractionType,
+): Promise<IMemeInteractionDocument | null> {
+  try {
+    const condition = {
+      deviceId: user.deviceId,
+      memeId: meme._id,
+      interactionType,
+    };
+
+    // 'save' interaction은 isDeleted 조건 검색 필요없음
+    const isDeletedCondition = interactionType !== InteractionType.SAVE ? { isDeleted: false } : {};
+
+    const memeInteraction = await MemeInteractionModel.findOne({
+      ...condition,
+      ...isDeletedCondition,
+    });
+
+    return memeInteraction || null;
+  } catch (error) {
+    logger.error(`Failed to get a MemeInteraction Info(${meme._id} - ${interactionType})`, {
+      error,
+    });
+    throw new CustomError(
+      `Failed to get a MemeInteraction Info(${meme._id} - ${interactionType})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+async function getMemeInteractionInfoWithCondition(
+  user: IUserDocument,
+  meme: IMemeDocument,
+  interactionType: InteractionType,
+  findCondition: Partial<IMemeInteractionDocument> = {},
+): Promise<IMemeInteractionDocument | null> {
+  try {
+    const condition: Partial<IMemeInteractionDocument> = {
+      deviceId: user.deviceId,
+      memeId: meme._id,
+      interactionType,
+      ...findCondition,
+    };
+
+    const memeInteraction = await MemeInteractionModel.findOne(condition);
+    return memeInteraction || null;
+  } catch (err) {
+    logger.error(`Failed to get a MemeInteraction Info(${meme._id} - ${interactionType})`);
+    throw new CustomError(
+      `Failed to get a MemeInteraction Info(${meme._id} - ${interactionType})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+async function getMemeInteractionCount(
+  user: IUserDocument,
+  interactionType: InteractionType,
+): Promise<number> {
+  try {
+    const count = await MemeInteractionModel.countDocuments({
+      deviceId: user.deviceId,
+      interactionType,
+      isDeleted: false,
+    });
+    return count;
+  } catch (err) {
+    logger.error(`Failed to count MemeInteraction(${interactionType})`);
+    throw new CustomError(
+      `Failed to count MemeInteraction(${interactionType}) (${err.message})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+async function getMemeInteractionList(
+  page: number,
+  size: number,
+  user: IUserDocument,
+  interactionType: InteractionType,
+): Promise<IMemeInteractionDocument[]> {
+  try {
+    const memeInteractionList = await MemeInteractionModel.find(
+      {
+        deviceId: user.deviceId,
+        interactionType: InteractionType.SAVE,
+        isDeleted: false,
+      },
+      { isDeleted: 0 },
+    )
+      .skip((page - 1) * size)
+      .limit(size)
+      .sort({ createdAt: -1 });
+
+    return memeInteractionList;
+  } catch (err) {
+    logger.error(`Failed to count MemeInteraction(${interactionType})`);
+    throw new CustomError(
+      `Failed to count MemeInteraction(${interactionType}) (${err.message})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+async function createMemeInteraction(
+  user: IUserDocument,
+  meme: IMemeDocument,
+  interactionType: InteractionType,
+): Promise<IMemeInteractionDocument> {
+  try {
+    const newMemeInteraction = new MemeInteractionModel({
+      deviceId: user.deviceId,
+      memeId: meme._id,
+      interactionType,
+    });
+    await newMemeInteraction.save();
+    return newMemeInteraction;
+  } catch (err) {
+    logger.error(`Failed to create a MemeInteraction(${meme._id} - ${interactionType})`);
+    throw new CustomError(
+      `Failed to create a MemeInteraction(${meme._id} - ${interactionType})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+async function updateMemeInteraction(
+  user: IUserDocument,
+  meme: IMemeDocument,
+  interactionType: InteractionType,
+): Promise<void> {
+  switch (interactionType) {
+    case InteractionType.SAVE:
+      await MemeInteractionModel.findOneAndUpdate(
+        { memeId: meme._id, deviceId: user.deviceId, interactionType },
+        { $set: { isDeleted: false } },
+      );
+      logger.debug(`[${interactionType}] interaction - updated isDeleted to 'false'`);
+      break;
+
+    case InteractionType.REACTION:
+      await MemeModel.findOneAndUpdate(
+        { memeId: meme._id, isDeleted: false },
+        { $inc: { reaction: 1 } },
+        {
+          projection: { _id: 0, createdAt: 0, updatedAt: 0 },
+          returnDocument: 'after',
+        },
+      ).lean();
+      logger.debug(`[${interactionType}] interaction - increased Meme reaction count`);
+      break;
+
+    case InteractionType.SHARE:
+    case InteractionType.WATCH:
+      logger.debug(`${interactionType} interaction don't need to be updated. `);
+      break;
+
+    default:
+      logger.error(`Unsupported interactionType(${interactionType})`);
+      throw new CustomError(
+        `Unsupported interactionType(${interactionType})`,
+        HttpCode.BAD_REQUEST,
+      );
+  }
+}
+
+async function deleteMemeInteraction(
+  user: IUserDocument,
+  meme: IMemeDocument,
+  interactionType: InteractionType,
+): Promise<IMemeInteractionDocument> {
+  try {
+    const memeInteraction = await MemeInteractionModel.findOneAndUpdate(
+      { deviceId: user.deviceId, memeId: meme._id, interactionType: InteractionType.SAVE },
+      {
+        isDeleted: true,
+      },
+    );
+
+    return memeInteraction;
+  } catch (err) {
+    logger.error(`Failed to delete a MemeInteraction(${meme._id} - ${interactionType})`);
+    throw new CustomError(
+      `Failed to delete a MemeInteraction(${meme._id} - ${interactionType})`,
+      HttpCode.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+export {
+  getMemeInteractionInfo,
+  getMemeInteractionInfoWithCondition,
+  getMemeInteractionCount,
+  getMemeInteractionList,
+  createMemeInteraction,
+  updateMemeInteraction,
+  deleteMemeInteraction,
+};

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -147,13 +147,15 @@ async function getLastSeenMemeList(user: IUserDocument): Promise<IMemeGetRespons
     ).lean();
 
     const getLastSeenMemeList = await MemeService.getMemeListWithKeywordsAndisSaved(user, memeList);
-    logger.info(`Get lastSeenMeme - deviceId(${user.deviceId}), memeList(${getLastSeenMemeList})`);
+    logger.info(
+      `Get lastSeenMemeList - deviceId(${user.deviceId}), memeList(${getLastSeenMemeList})`,
+    );
 
     return getLastSeenMemeList;
   } catch (err) {
-    logger.error(`Failed get lastSeenMeme`, err.message);
+    logger.error(`Failed get lastSeenMemeList`, err.message);
     throw new CustomError(
-      `Failed get lastSeenMeme(${err.message})`,
+      `Failed get lastSeenMemeList(${err.message})`,
       HttpCode.INTERNAL_SERVER_ERROR,
     );
   }

--- a/test/meme/delete-meme.test.ts
+++ b/test/meme/delete-meme.test.ts
@@ -3,8 +3,10 @@ import request from 'supertest';
 import app from '../../src/app';
 import { KeywordModel } from '../../src/model/keyword';
 import { MemeModel } from '../../src/model/meme';
+import { UserModel } from '../../src/model/user';
 import { createMockData as createKeywordMockData } from '../util/keyword.mock';
 import { createMockData } from '../util/meme.mock';
+import { mockUser } from '../util/user.mock';
 
 let testMemeId = '';
 let keywordIds = [];
@@ -20,10 +22,13 @@ describe("[DELETE] '/api/meme/:memeId' ", () => {
     await MemeModel.insertMany(mockDatas);
     memeList = await MemeModel.find({});
     testMemeId = memeList[0]._id.toString();
+
+    await UserModel.insertMany(mockUser);
   });
 
   afterAll(async () => {
     await MemeModel.deleteMany({});
+    await UserModel.deleteMany({});
   });
 
   it('should delete a meme', async () => {
@@ -31,7 +36,7 @@ describe("[DELETE] '/api/meme/:memeId' ", () => {
     expect(response.statusCode).toBe(200);
     expect(response.body.data).toBeTruthy();
 
-    response = await request(app).get(`/api/meme/list`);
+    response = await request(app).get(`/api/meme/list`).set('x-device-id', 'deviceId');
     expect(response.statusCode).toBe(200);
     expect(response.body.data.memeList.length).toBe(1);
   });

--- a/test/meme/get-meme-list.test.ts
+++ b/test/meme/get-meme-list.test.ts
@@ -3,8 +3,10 @@ import request from 'supertest';
 import app from '../../src/app';
 import { KeywordModel } from '../../src/model/keyword';
 import { MemeModel } from '../../src/model/meme';
+import { UserModel } from '../../src/model/user';
 import { createMockData as createKeywordMockData } from '../util/keyword.mock';
 import { createMockData } from '../util/meme.mock';
+import { mockUser } from '../util/user.mock';
 
 const totalCount = 15;
 let keywordIds = [];
@@ -19,14 +21,17 @@ describe("[GET] '/api/meme/list' ", () => {
 
     const memeMockDatas = createMockData(totalCount, 1, keywordIds);
     await MemeModel.insertMany(memeMockDatas);
+
+    await UserModel.insertMany(mockUser);
   });
 
   afterAll(async () => {
     await MemeModel.deleteMany({});
+    await UserModel.deleteMany({});
   });
 
   it('should return the default paginated list of memes', async () => {
-    const response = await request(app).get('/api/meme/list');
+    const response = await request(app).get('/api/meme/list').set('x-device-id', 'deviceId');
     expect(response.statusCode).toBe(200);
     expect(response.body.data.pagination.total).toBe(totalCount);
     expect(response.body.data.pagination.page).toBe(1);
@@ -42,7 +47,9 @@ describe("[GET] '/api/meme/list' ", () => {
   it('should return paginated list of memes for specific page and size', async () => {
     const size = 5;
     const page = 1;
-    const response = await request(app).get(`/api/meme/list?page=${page}&size=${size}`);
+    const response = await request(app)
+      .get(`/api/meme/list?page=${page}&size=${size}`)
+      .set('x-device-id', 'deviceId');
 
     expect(response.statusCode).toBe(200);
     expect(response.body.data.pagination.total).toBe(totalCount);
@@ -54,7 +61,9 @@ describe("[GET] '/api/meme/list' ", () => {
   it('should return an error for invalid page', async () => {
     const size = 5;
     const page = -1;
-    const response = await request(app).get(`/api/meme/list?page=${page}&size=${size}`);
+    const response = await request(app)
+      .get(`/api/meme/list?page=${page}&size=${size}`)
+      .set('x-device-id', 'deviceId');
 
     expect(response.statusCode).toBe(400);
   });
@@ -62,7 +71,9 @@ describe("[GET] '/api/meme/list' ", () => {
   it('should return an error for invalid size', async () => {
     const size = -1;
     const page = 3;
-    const response = await request(app).get(`/api/meme/list?page=${page}&size=${size}`);
+    const response = await request(app)
+      .get(`/api/meme/list?page=${page}&size=${size}`)
+      .set('x-device-id', 'deviceId');
 
     expect(response.statusCode).toBe(400);
   });

--- a/test/meme/get-meme.test.ts
+++ b/test/meme/get-meme.test.ts
@@ -4,8 +4,10 @@ import request from 'supertest';
 import app from '../../src/app';
 import { KeywordModel } from '../../src/model/keyword';
 import { MemeModel } from '../../src/model/meme';
+import { UserModel } from '../../src/model/user';
 import { createMockData as createKeywordMockData } from '../util/keyword.mock';
 import { createMockData as createMemeMockData } from '../util/meme.mock';
+import { mockUser } from '../util/user.mock';
 
 let testMemeId = '';
 let keywordIds = [];
@@ -23,21 +25,28 @@ describe("[GET] '/api/meme/:memeId' ", () => {
 
     memeList = await MemeModel.find({});
     testMemeId = memeList[0]._id.toString();
+
+    await UserModel.insertMany(mockUser);
   });
 
   afterAll(async () => {
     await MemeModel.deleteMany({});
+    await UserModel.deleteMany({});
   });
 
   it('should get a meme', async () => {
-    const response = await request(app).get(`/api/meme/${testMemeId}`);
+    const response = await request(app)
+      .get(`/api/meme/${testMemeId}`)
+      .set('x-device-id', 'deviceId');
     expect(response.body.data._id).toBe(testMemeId);
     expect(response.body.data).toHaveProperty('keywords');
     expect(response.body.data.isTodayMeme).toBeFalsy();
   });
 
   it('should not get a meme with nonexisting id', async () => {
-    const response = await request(app).get(`/api/meme/nonexistingId`);
+    const response = await request(app)
+      .get(`/api/meme/nonexistingId`)
+      .set('x-device-id', 'deviceId');
     expect(response.statusCode).toBe(400);
   });
 });

--- a/test/meme/get-recommend-meme-list.test.ts
+++ b/test/meme/get-recommend-meme-list.test.ts
@@ -3,31 +3,35 @@ import request from 'supertest';
 import app from '../../src/app';
 import { KeywordModel } from '../../src/model/keyword';
 import { MemeModel } from '../../src/model/meme';
+import { UserModel } from '../../src/model/user';
 import { createMockData as createKeywordMockData } from '../util/keyword.mock';
 import { createMockData } from '../util/meme.mock';
+import { mockUser } from '../util/user.mock';
 
 const totalCount = 10;
 let keywordIds = [];
-let keywords = [];
 
 describe("[GET] '/api/meme/recommend-memes' ", () => {
   beforeEach(async () => {
     const keywordMockDatas = createKeywordMockData(5);
     const createdKeywords = await KeywordModel.insertMany(keywordMockDatas);
     keywordIds = createdKeywords.map((k) => k._id);
-    keywords = createdKeywords.map((k) => k.name);
+    await UserModel.insertMany(mockUser);
   });
 
   afterEach(async () => {
     await MemeModel.deleteMany({});
     await KeywordModel.deleteMany({});
+    await UserModel.deleteMany({});
   });
 
   it('should return list of recommend-memes - default size: 5', async () => {
     const mockDatas = createMockData(totalCount, 5, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
-    const response = await request(app).get('/api/meme/recommend-memes');
+    const response = await request(app)
+      .get('/api/meme/recommend-memes')
+      .set('x-device-id', 'deviceId');
     expect(response.statusCode).toBe(200);
     expect(response.body.data.length).toBe(5);
   });
@@ -37,9 +41,9 @@ describe("[GET] '/api/meme/recommend-memes' ", () => {
     const mockDatas = createMockData(totalCount, customizedTodayMemeCount, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
-    const response = await request(app).get(
-      `/api/meme/recommend-memes?size=${customizedTodayMemeCount}`,
-    );
+    const response = await request(app)
+      .get(`/api/meme/recommend-memes?size=${customizedTodayMemeCount}`)
+      .set('x-device-id', 'deviceId');
 
     expect(response.statusCode).toBe(200);
     expect(response.body.data.length).toBe(customizedTodayMemeCount);
@@ -50,9 +54,9 @@ describe("[GET] '/api/meme/recommend-memes' ", () => {
     const mockDatas = createMockData(totalCount, customizedTodayMemeCount, keywordIds);
     await MemeModel.insertMany(mockDatas);
 
-    const response = await request(app).get(
-      `/api/meme/recommend-memes?size=${customizedTodayMemeCount}`,
-    );
+    const response = await request(app)
+      .get(`/api/meme/recommend-memes?size=${customizedTodayMemeCount}`)
+      .set('x-device-id', 'deviceId');
 
     expect(response.statusCode).toBe(400);
   });

--- a/test/meme/patch-meme.test.ts
+++ b/test/meme/patch-meme.test.ts
@@ -44,7 +44,8 @@ describe("[PATCH] '/api/meme/:memeId' ", () => {
 
     response = await request(app).get(`/api/meme/${testMemeId}`).set('x-device-id', 'deviceId');
     expect(response.body.data._id).toBe(memeList[0]._id.toString());
-    expect(response.body.data.keywords).toHaveProperty({ _id: keywordIds[1], name: keywords[1] });
+    expect(response.body.data.keywords[0]).toHaveProperty('_id');
+    expect(response.body.data.keywords[0]).toHaveProperty('name');
     expect(response.body.data.isTodayMeme).toBeTruthy();
   });
 });

--- a/test/meme/patch-meme.test.ts
+++ b/test/meme/patch-meme.test.ts
@@ -3,8 +3,10 @@ import request from 'supertest';
 import app from '../../src/app';
 import { KeywordModel } from '../../src/model/keyword';
 import { IMemeUpdatePayload, MemeModel } from '../../src/model/meme';
+import { UserModel } from '../../src/model/user';
 import { createMockData as createKeywordMockData } from '../util/keyword.mock';
 import { createMockData } from '../util/meme.mock';
+import { mockUser } from '../util/user.mock';
 
 let memeList = [];
 let keywordIds = [];
@@ -22,10 +24,13 @@ describe("[PATCH] '/api/meme/:memeId' ", () => {
     await MemeModel.insertMany(mockDatas);
     memeList = await MemeModel.find({});
     testMemeId = memeList[0]._id.toString();
+
+    await UserModel.insertMany(mockUser);
   });
 
   afterAll(async () => {
     await MemeModel.deleteMany({});
+    await UserModel.deleteMany({});
   });
 
   it('should patch a meme', async () => {
@@ -37,9 +42,9 @@ describe("[PATCH] '/api/meme/:memeId' ", () => {
     expect(response.statusCode).toBe(200);
     expect(response.body.data._id).toBe(memeList[0]._id.toString());
 
-    response = await request(app).get(`/api/meme/${testMemeId}`);
+    response = await request(app).get(`/api/meme/${testMemeId}`).set('x-device-id', 'deviceId');
     expect(response.body.data._id).toBe(memeList[0]._id.toString());
-    expect(response.body.data.keywords).toEqual([keywords[1]]);
+    expect(response.body.data.keywords).toHaveProperty({ _id: keywordIds[1], name: keywords[1] });
     expect(response.body.data.isTodayMeme).toBeTruthy();
   });
 });


### PR DESCRIPTION
## 개선
- `...s` -> `...List` 로 변수명 함수명 변경
- MemeInteraction Service 구현, 다른 service단에서 직접 MemeInteractionModel 사용하지않도록 변경
- IMemeGetResponse 타입 수정, IMemeInteraction Schema 선언 수정
- null 체크를 lodash _.isNull 쓰도록 명시적으로 변경

## 버그
- swagger에 header 없는 api 추가
- 내가 저장한 밈인지 조회하는 코드에서 쿼리 조건 수정 (`type` 필드가 아닌 `interactionType`임)
- 테스트 코드 수정

## 정책 변경
없음
