### PR TITLE
모두 plain object로 변환해서 넘기기

### DIFF
--- a/src/service/meme.service.ts
+++ b/src/service/meme.service.ts
@@ -58,7 +58,7 @@ async function getTodayMemeList(
     const todayMemeList = await MemeModel.find(
       { isDeleted: false, isTodayMeme: true },
       { isDeleted: 0 },
-    );
+    ).lean();
 
     const memeList = await getMemeListWithKeywordsAndisSaved(user, todayMemeList);
 
@@ -87,7 +87,8 @@ async function getAllMemeList(
   const memeList = await MemeModel.find({ isDeleted: false }, { isDeleted: 0 })
     .skip((page - 1) * size)
     .limit(size)
-    .sort({ createdAt: -1 });
+    .sort({ createdAt: -1 })
+    .lean();
 
   const allMemeList = await getMemeListWithKeywordsAndisSaved(user, memeList);
 


### PR DESCRIPTION
`getMemeListWithKeywordsAndisSaved` 함수로 넘길때 모두 `lean()`해서 넘기도록 변경