### PR TITLE
밈 저장 취소 시 성공했음에도 false로 반환되는 문제, 밈 조회 시 isSaved 필드가 제대로 동작하지않는 문제 수정

### DIFF
--- a/src/model/memeRecommendWatch.ts
+++ b/src/model/memeRecommendWatch.ts
@@ -3,26 +3,20 @@ import mongoose, { Schema, Document, Types } from 'mongoose';
 export interface IMemeRecommendWatchCreatePayload {
   deviceId: string;
   startDate: Date;
-  memeIds: Types.ObjectId[];
-}
-
-export interface IMemeRecommendWatchUpdatePayload {
-  deviceId?: string;
-  startDate?: Date;
-  memeIds?: Types.ObjectId[];
+  memeId: Types.ObjectId;
 }
 
 export interface IMemeRecommendWatch {
   deviceId: string;
   startDate: Date;
-  memeIds: Types.ObjectId[];
+  memeId: Types.ObjectId;
 }
 
 export interface IMemeRecommendWatchDocument extends Document {
   _id: Types.ObjectId;
   deviceId: string;
   startDate: Date;
-  memeIds: Types.ObjectId[];
+  memeId: Types.ObjectId;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -32,7 +26,7 @@ const MemeRecommendWatchSchema: Schema = new Schema(
     deviceId: { type: String, required: true },
     startDate: { type: Date, required: true },
     isDeleted: { type: Boolean, required: true, default: false },
-    memeIds: [{ type: Types.ObjectId, ref: 'Meme', required: true }],
+    memeId: { type: Types.ObjectId, ref: 'Meme', required: true },
   },
   {
     timestamps: true,
@@ -42,6 +36,6 @@ const MemeRecommendWatchSchema: Schema = new Schema(
 );
 
 export const MemeRecommendWatchModel = mongoose.model<IMemeRecommendWatchDocument>(
-  'MemeRecommendWatch',
+  'memeRecommendWatch',
   MemeRecommendWatchSchema,
 );

--- a/src/routes/meme.ts
+++ b/src/routes/meme.ts
@@ -18,6 +18,7 @@ import {
   getRequestedMemeInfo,
   getKeywordInfoByName,
   getRequestedUserInfo,
+  getRequestedMemeSaveInfo,
 } from '../middleware/requestedInfo';
 
 const router = express.Router();
@@ -980,7 +981,7 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  *                   type: null
  *                   example: null
  *       404:
- *         description: Meme or user not found
+ *         description: Meme / User / Meme Interaction NOT FOUND
  *         content:
  *           application/json:
  *             schema:
@@ -1019,7 +1020,13 @@ router.post('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, createM
  *                   example: null
  *
  * */
-router.delete('/:memeId/save', getRequestedUserInfo, getRequestedMemeInfo, deleteMemeSave);
+router.delete(
+  '/:memeId/save',
+  getRequestedUserInfo,
+  getRequestedMemeInfo,
+  getRequestedMemeSaveInfo,
+  deleteMemeSave,
+); // meme 저장하기 취소 (삭제)
 
 /**
  * @swagger

--- a/src/service/meme.service.ts
+++ b/src/service/meme.service.ts
@@ -230,11 +230,15 @@ async function createMemeInteraction(
   interactionType: InteractionType,
 ): Promise<boolean> {
   try {
+    // 'save' interaction은 isDeleted 조건 검색 필요없음
+    const isDeletedFilter = interactionType === InteractionType.SAVE ? false : true;
+
     // interaction 조회
     const memeInteraction = await MemeInteractionService.getMemeInteractionInfo(
       user,
       meme,
       interactionType,
+      isDeletedFilter,
     );
 
     if (_.isNull(memeInteraction)) {
@@ -242,7 +246,7 @@ async function createMemeInteraction(
       await MemeInteractionService.createMemeInteraction(user, meme, interactionType);
     } else {
       logger.info(
-        `Already ${interactionType} meme - deviceId(${user.deviceId}), memeId(${meme._id}`,
+        `Already ${interactionType} meme - deviceId(${user.deviceId}), memeId(${meme._id})`,
       );
 
       // interactionType에 따른 동작 처리 (MemeInteracionService에서 진행)

--- a/src/service/meme.service.ts
+++ b/src/service/meme.service.ts
@@ -259,18 +259,6 @@ async function createMemeInteraction(
 
 async function deleteMemeSave(user: IUserDocument, meme: IMemeDocument): Promise<boolean> {
   try {
-    const memeSaveInteraction = await MemeInteractionService.getMemeInteractionInfoWithCondition(
-      user,
-      meme,
-      InteractionType.SAVE,
-      { isDeleted: true },
-    );
-
-    if (!_.isNull(memeSaveInteraction)) {
-      logger.info(`Already delete memeSave - deviceId(${user.deviceId}), memeId(${meme._id}`);
-      return false;
-    }
-
     await MemeInteractionService.deleteMemeInteraction(user, meme, InteractionType.SAVE);
     return true;
   } catch (err) {
@@ -281,6 +269,7 @@ async function deleteMemeSave(user: IUserDocument, meme: IMemeDocument): Promise
     );
   }
 }
+
 async function getTopReactionImage(keyword: IKeywordDocument): Promise<string> {
   try {
     const topReactionMeme: IMemeDocument = await MemeModel.findOne({

--- a/src/service/meme.service.ts
+++ b/src/service/meme.service.ts
@@ -34,6 +34,7 @@ async function getMemeWithKeywords(
       user,
       meme,
       InteractionType.SAVE,
+      true, // {isDeleted: false} 조건으로 save 상태인지 확인
     );
 
     return {
@@ -115,6 +116,7 @@ async function getMemeListWithKeywordsAndisSaved(
           user,
           meme,
           InteractionType.SAVE,
+          true, // {isDeleted: false} 조건으로 save 상태인지 확인
         );
         return {
           ..._.omit(meme, 'keywordIds'),

--- a/src/service/memeInteraction.service.ts
+++ b/src/service/memeInteraction.service.ts
@@ -13,6 +13,7 @@ async function getMemeInteractionInfo(
   user: IUserDocument,
   meme: IMemeDocument,
   interactionType: InteractionType,
+  isDeletedFilter: boolean = true,
 ): Promise<IMemeInteractionDocument | null> {
   try {
     const condition = {
@@ -21,8 +22,9 @@ async function getMemeInteractionInfo(
       interactionType,
     };
 
-    // 'save' interaction은 isDeleted 조건 검색 필요없음
-    const isDeletedCondition = interactionType !== InteractionType.SAVE ? { isDeleted: false } : {};
+    // isDeletedFilter true인 경우 { isDeleted: false }로 검색
+    // isDeletedFilter false인 경우 {}로 검색 (삭제된 도큐먼트도 검색)
+    const isDeletedCondition = isDeletedFilter ? { isDeleted: false } : {};
 
     const memeInteraction = await MemeInteractionModel.findOne({
       ...condition,

--- a/src/service/memeInteraction.service.ts
+++ b/src/service/memeInteraction.service.ts
@@ -145,6 +145,7 @@ async function updateMemeInteraction(
   interactionType: InteractionType,
 ): Promise<void> {
   switch (interactionType) {
+    // 'save' isDeleted false로 변경
     case InteractionType.SAVE:
       await MemeInteractionModel.findOneAndUpdate(
         { memeId: meme._id, deviceId: user.deviceId, interactionType },
@@ -153,6 +154,8 @@ async function updateMemeInteraction(
       logger.debug(`[${interactionType}] interaction - updated isDeleted to 'false'`);
       break;
 
+    // 'reaction' Meme.reaction count 올리기
+    // User의 'reaction' count는 밈당 1번
     case InteractionType.REACTION:
       await MemeModel.findOneAndUpdate(
         { _id: meme._id, isDeleted: false },
@@ -165,6 +168,7 @@ async function updateMemeInteraction(
       logger.debug(`[${interactionType}] interaction - increased Meme reaction count`);
       break;
 
+    // 'share', 'watch' 추가 동작 필요없음
     case InteractionType.SHARE:
     case InteractionType.WATCH:
       logger.debug(`${interactionType} interaction don't need to be updated. `);

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -10,7 +10,6 @@ import { IMemeDocument, IMemeGetResponse, MemeModel } from '../model/meme';
 import { InteractionType, MemeInteractionModel } from '../model/memeInteraction';
 import {
   MemeRecommendWatchModel,
-  IMemeRecommendWatchUpdatePayload,
   IMemeRecommendWatchCreatePayload,
 } from '../model/memeRecommendWatch';
 import { IUser, IUserDocument, IUserInfos, UserModel } from '../model/user';
@@ -202,40 +201,40 @@ async function getSavedMemeList(
 async function createMemeRecommendWatch(user: IUserDocument, meme: IMemeDocument): Promise<number> {
   try {
     const todayWeekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+
     const memeRecommendWatch = await MemeRecommendWatchModel.findOne({
-      memeIds: meme._id,
+      memeId: meme._id,
       startDate: todayWeekStart,
       deviceId: user.deviceId,
       isDeleted: false,
     });
 
-    if (!_.isNull(memeRecommendWatch)) {
-      logger.info(`Already watched recommend meme - deviceId(${user.deviceId})`);
-
-      const updatedMemeList = Array.from(
-        new Set([...memeRecommendWatch.memeIds, meme._id].map((id) => id.toString())),
-      ).map((id) => new Types.ObjectId(id));
-
-      const updatePayload: IMemeRecommendWatchUpdatePayload = {
-        memeIds: updatedMemeList,
+    // 해당 추천 밈을 처음 보는 경우
+    if (_.isNull(memeRecommendWatch)) {
+      // 추천 밈 본 기록 남기기
+      const createPayload: IMemeRecommendWatchCreatePayload = {
+        deviceId: user.deviceId,
+        startDate: startOfWeek(new Date(), { weekStartsOn: 1 }),
+        memeId: meme._id,
       };
 
-      await MemeRecommendWatchModel.findOneAndUpdate(
-        { _id: memeRecommendWatch._id },
-        { $set: updatePayload },
-      );
-      return updatePayload.memeIds.length;
+      // MemeRecommendWatch에 memeId 추가
+      // MemeInteraction에 memeId의 watch 타입 추가
+      await Promise.all([
+        MemeRecommendWatchModel.create(createPayload),
+        MemeService.createMemeInteraction(user, meme, InteractionType.WATCH),
+      ]);
+    } else {
+      logger.info(`Already watched recommend meme - deviceId(${user.deviceId})`);
     }
 
-    const createPayload: IMemeRecommendWatchCreatePayload = {
+    const memeRecommendWatchCount = await MemeRecommendWatchModel.countDocuments({
+      startDate: todayWeekStart,
       deviceId: user.deviceId,
-      startDate: startOfWeek(new Date(), { weekStartsOn: 1 }),
-      memeIds: [meme._id],
-    };
+      isDeleted: false,
+    });
 
-    await MemeRecommendWatchModel.create(createPayload);
-
-    return 1;
+    return memeRecommendWatchCount;
   } catch (err) {
     logger.error(`Failed create memeRecommendWatch`, err.message);
     throw new CustomError(

--- a/test/meme/get-meme-list.test.ts
+++ b/test/meme/get-meme-list.test.ts
@@ -37,7 +37,7 @@ describe("[GET] '/api/meme/list' ", () => {
     expect(response.body.data.pagination.page).toBe(1);
     expect(response.body.data.pagination.totalPages).toBe(2);
     expect(response.body.data.memeList.length).toBe(10);
-    expect(response.body.data.memeList[0]).toHaveProperty('keywordIds');
+    expect(response.body.data.memeList[0]).toHaveProperty('keywords');
     expect(response.body.data.memeList[0]).toHaveProperty('image');
     expect(response.body.data.memeList[0]).toHaveProperty('source');
     expect(response.body.data.memeList[0]).toHaveProperty('isTodayMeme');


### PR DESCRIPTION
## 버그
- 밈 저장 취소 API를 호출했을때, 저장 취소를 실패했음에도 `200` 상태코드와 `data: false` 가 넘어오는 문제가 있어서 수정
- 저장되지않은 밈인데도 밈 조회 API에서 `isSaved: true`로 넘어오는 문제가 있어서 수정

## 개선
- MemeInteraction 조회 시 상황에 따라 isDeleted 포함 여부를 변경할 수 있도록 인자값 추가
- MemeInteraction 미들웨어를 추가해서 save interaction이 있는 밈인 경우만 서비스 레벨로 넘어가도록 개선