### PR TITLE
추천 밈 보기 로직 개선, MemeRecommendWatchModel schema 변경

### DIFF
--- a/src/model/memeRecommendWatch.ts
+++ b/src/model/memeRecommendWatch.ts
@@ -6,12 +6,6 @@ export interface IMemeRecommendWatchCreatePayload {
   memeId: Types.ObjectId;
 }
 
-export interface IMemeRecommendWatchUpdatePayload {
-  deviceId?: string;
-  startDate?: Date;
-  memeId?: Types.ObjectId;
-}
-
 export interface IMemeRecommendWatch {
   deviceId: string;
   startDate: Date;

--- a/src/model/memeRecommendWatch.ts
+++ b/src/model/memeRecommendWatch.ts
@@ -3,26 +3,26 @@ import mongoose, { Schema, Document, Types } from 'mongoose';
 export interface IMemeRecommendWatchCreatePayload {
   deviceId: string;
   startDate: Date;
-  memeIds: Types.ObjectId[];
+  memeId: Types.ObjectId;
 }
 
 export interface IMemeRecommendWatchUpdatePayload {
   deviceId?: string;
   startDate?: Date;
-  memeIds?: Types.ObjectId[];
+  memeId?: Types.ObjectId;
 }
 
 export interface IMemeRecommendWatch {
   deviceId: string;
   startDate: Date;
-  memeIds: Types.ObjectId[];
+  memeId: Types.ObjectId;
 }
 
 export interface IMemeRecommendWatchDocument extends Document {
   _id: Types.ObjectId;
   deviceId: string;
   startDate: Date;
-  memeIds: Types.ObjectId[];
+  memeId: Types.ObjectId;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -32,7 +32,7 @@ const MemeRecommendWatchSchema: Schema = new Schema(
     deviceId: { type: String, required: true },
     startDate: { type: Date, required: true },
     isDeleted: { type: Boolean, required: true, default: false },
-    memeIds: [{ type: Types.ObjectId, ref: 'Meme', required: true }],
+    memeId: { type: Types.ObjectId, ref: 'Meme', required: true },
   },
   {
     timestamps: true,
@@ -42,6 +42,6 @@ const MemeRecommendWatchSchema: Schema = new Schema(
 );
 
 export const MemeRecommendWatchModel = mongoose.model<IMemeRecommendWatchDocument>(
-  'MemeRecommendWatch',
+  'memeRecommendWatch',
   MemeRecommendWatchSchema,
 );

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -227,14 +227,14 @@ async function createMemeRecommendWatch(user: IUserDocument, meme: IMemeDocument
     } else {
       logger.info(`Already watched recommend meme - deviceId(${user.deviceId})`);
     }
+
+    const memeRecommendWatchCount = await MemeRecommendWatchModel.countDocuments({
+      startDate: todayWeekStart,
       deviceId: user.deviceId,
-      startDate: startOfWeek(new Date(), { weekStartsOn: 1 }),
-      memeIds: [meme._id],
-    };
+      isDeleted: false,
+    });
 
-    await MemeRecommendWatchModel.create(createPayload);
-
-    return 1;
+    return memeRecommendWatchCount;
   } catch (err) {
     logger.error(`Failed create memeRecommendWatch`, err.message);
     throw new CustomError(

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -10,7 +10,6 @@ import { IMemeDocument, IMemeGetResponse, MemeModel } from '../model/meme';
 import { InteractionType, MemeInteractionModel } from '../model/memeInteraction';
 import {
   MemeRecommendWatchModel,
-  IMemeRecommendWatchUpdatePayload,
   IMemeRecommendWatchCreatePayload,
 } from '../model/memeRecommendWatch';
 import { IUser, IUserDocument, IUserInfos, UserModel } from '../model/user';
@@ -202,32 +201,32 @@ async function getSavedMemeList(
 async function createMemeRecommendWatch(user: IUserDocument, meme: IMemeDocument): Promise<number> {
   try {
     const todayWeekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+
     const memeRecommendWatch = await MemeRecommendWatchModel.findOne({
-      memeIds: meme._id,
+      memeId: meme._id,
       startDate: todayWeekStart,
       deviceId: user.deviceId,
       isDeleted: false,
     });
 
-    if (!_.isNull(memeRecommendWatch)) {
-      logger.info(`Already watched recommend meme - deviceId(${user.deviceId})`);
-
-      const updatedMemeList = Array.from(
-        new Set([...memeRecommendWatch.memeIds, meme._id].map((id) => id.toString())),
-      ).map((id) => new Types.ObjectId(id));
-
-      const updatePayload: IMemeRecommendWatchUpdatePayload = {
-        memeIds: updatedMemeList,
+    // 해당 추천 밈을 처음 보는 경우
+    if (_.isNull(memeRecommendWatch)) {
+      // 추천 밈 본 기록 남기기
+      const createPayload: IMemeRecommendWatchCreatePayload = {
+        deviceId: user.deviceId,
+        startDate: startOfWeek(new Date(), { weekStartsOn: 1 }),
+        memeId: meme._id,
       };
 
-      await MemeRecommendWatchModel.findOneAndUpdate(
-        { _id: memeRecommendWatch._id },
-        { $set: updatePayload },
-      );
-      return updatePayload.memeIds.length;
+      // MemeRecommendWatch에 memeId 추가
+      // MemeInteraction에 memeId의 watch 타입 추가
+      await Promise.all([
+        MemeRecommendWatchModel.create(createPayload),
+        MemeService.createMemeInteraction(user, meme, InteractionType.WATCH),
+      ]);
+    } else {
+      logger.info(`Already watched recommend meme - deviceId(${user.deviceId})`);
     }
-
-    const createPayload: IMemeRecommendWatchCreatePayload = {
       deviceId: user.deviceId,
       startDate: startOfWeek(new Date(), { weekStartsOn: 1 }),
       memeIds: [meme._id],

--- a/test/meme/get-meme-list.test.ts
+++ b/test/meme/get-meme-list.test.ts
@@ -37,7 +37,7 @@ describe("[GET] '/api/meme/list' ", () => {
     expect(response.body.data.pagination.page).toBe(1);
     expect(response.body.data.pagination.totalPages).toBe(2);
     expect(response.body.data.memeList.length).toBe(10);
-    expect(response.body.data.memeList[0]).toHaveProperty('keywordIds');
+    expect(response.body.data.memeList[0]).toHaveProperty('keywords');
     expect(response.body.data.memeList[0]).toHaveProperty('image');
     expect(response.body.data.memeList[0]).toHaveProperty('source');
     expect(response.body.data.memeList[0]).toHaveProperty('isTodayMeme');


### PR DESCRIPTION
## 정책 확정
- 사용자는 'ㅋㅋ 리액션'은 밈 1개당 n번 클릭할 수 있다.
- 사용자 레벨의 'ㅋㅋ 리액션' 횟수는 밈 1개당 1번으로 간주한다. (100번 눌러도 1번)
- 밈의 'ㅋㅋ 리액션' 횟수는 사용자들이 누른 'ㅋㅋ 리액션'의 누적 횟수이다. (1번 유저가 A밈에 100번, 2번 유저가 A밈에 2번 누르면 A밈의 reaction은 102)

## 개선
- MemeRecommendWatchModel 스키마 변경: `memeIds` -> `memeId`로 변경 
  - 금주 추천밈을 볼 때마다 memeIds 필드에 해당 밈 id를 배열에 추가하는 방식으로 document를 업데이트해야하는데 코드가 그렇지 않음
  - memeRecommendWatchCount도 document 개수로 세고있음
  - 따라서, memeIds를 없애고 memeId로 변경

## 버그
- `/api/meme/:memeId/watch/recommend`인 경우 현재 추천 밈 본 횟수를 반환해줘야하는데 무조건 1을 반환하고 있는 문제가 있었음
