### PR TITLE
인기 키워드의 image 정보 조회 실패 시 에러 캐치하도록 변경

### DIFF
--- a/src/controller/keyword.controller.ts
+++ b/src/controller/keyword.controller.ts
@@ -47,7 +47,10 @@ const getTopKeywords = async (req: Request, res: Response, next: NextFunction) =
           const topReactionImage: string = await MemeService.getTopReactionImage(keyword);
           return { ...keyword, topReactionImage } as IKeywordWithImage;
         } catch (error) {
-          logger.error(`Error retrieving top reaction image for keyword: ${keyword}`, error);
+          logger.error(
+            `Error retrieving top reaction image for keyword: ${JSON.stringify(keyword._id)}`,
+            error,
+          );
           throw new CustomError(`Failed to get top reaction image`, HttpCode.INTERNAL_SERVER_ERROR);
         }
       },

--- a/src/service/meme.service.ts
+++ b/src/service/meme.service.ts
@@ -285,10 +285,14 @@ async function getTopReactionImage(keyword: IKeywordDocument): Promise<string> {
       reaction: -1,
     });
 
+    if (_.isNull(topReactionMeme)) {
+      throw new CustomError(`Failed get top reaction meme image`, HttpCode.NOT_FOUND);
+    }
+
     logger.info(`Get top reaction meme - keyword(${keyword.name}), meme(${topReactionMeme._id})`);
     return topReactionMeme.image;
   } catch (err) {
-    logger.error(`Failed get top reaction meme`, err.message);
+    logger.error(`Failed get top reaction meme image`, err.message);
     throw new CustomError(
       `Failed get top reaction meme(${err.message})`,
       HttpCode.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
- 로그 추가
- topReactionMeme 못찾았을 때 404 반환하도록 수정

근본적인 문제는 Meme Collection에서 `keywordIds` 필드가 string[]으로 저장되어있던 문제였으며, ObjectId[]로 변경해서 해결함