### PR TITLE
fix: 정렬 조건 추가

### DIFF
--- a/src/service/meme.service.ts
+++ b/src/service/meme.service.ts
@@ -207,7 +207,7 @@ async function searchMemeByKeyword(
     )
       .skip((page - 1) * size)
       .limit(size)
-      .sort({ reaction: -1 })
+      .sort({ reaction: -1, _id: 1 })
       .lean();
 
     const memeList = await getMemeListWithKeywordsAndisSavedAndisReaction(user, searchedMemeList);


### PR DESCRIPTION
### 원인
- reaction이 같을 경우 call할때마다 결과가 달라 다른 페이지인데 같은 결과를 내보내는 경우가 있음
- 그때문에 중복 _id값이 생겨서 오류가 발생하는 듯함
- _id(유니크값)로 정렬해서 중복 결과가 안생기도록 진행