### PR TITLE
feat: production 환경에서는 로그를 간결하게 남기도록 한다.

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -19,7 +19,10 @@ const FCM_PROJECT_ID = process.env.FCM_PROJECT_ID;
 const FCM_PRIVATE_KEY = process.env.FCM_PRIVATE_KEY;
 const FCM_CLIENT_EMAIL = process.env.FCM_CLIENT_EMAIL;
 
+const ENV = process.env.NODE_ENV;
+
 export default {
+  ENV,
   DB_URL,
   PORT,
   AWS_ACCESS_KEY_ID,


### PR DESCRIPTION
- 자세하게 로그를 남기도록 해뒀는데, prod 환경에서 로그가 너무 많이 찍혀서 실시간 대응하기가 힘들어서 간결하게 남기도록 일단 변경함
- 추후에 elk나 loki grafana 붙이게 되면 다시 재작업 예정

**- production 에서 `.env`에 `NODE_ENV=production` 설정 필요!**